### PR TITLE
escapes print_duration not founding the start time if not debug mode

### DIFF
--- a/triplets/rdf_parser.py
+++ b/triplets/rdf_parser.py
@@ -857,8 +857,8 @@ def export_to_cimxml(data, rdf_map=None, namespace_map={"rdf": "http://www.w3.or
                                              export_undefined,
                                              comment,
                                              debug))
-
-    _, start_time = print_duration("All XML created in memory ", start_time)
+    if debug:
+        _, start_time = print_duration("All XML created in memory ", start_time)
     ### Export XML ###
     exported_files = []
 


### PR DESCRIPTION
When not in debug mode the export breaks as it is unable to find the start time