### PR TITLE
Add CIM spreadsheet conversion CLI tools and multivalue support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,10 @@ dependencies = [
     "aniso8601",
 ]
 
+[project.scripts]
+cim-spreadsheet = "triplets.cli.cim_spreadsheet:main"
+cim-diff = "triplets.cli.cim_diff:main"
+
 [project.optional-dependencies]
 arrow = [
     "pyarrow>=14.0",
@@ -17,11 +21,15 @@ polars = [
     "polars>=1.0",
     "pyarrow>=14.0",
 ]
+excel = [
+    "openpyxl>=3.1.5",
+]
 dev = [
     "pytest>=7.0",
     "pytest-xdist",
     "polars>=1.0",
     "pyarrow>=14.0",
+    "openpyxl>=3.1.5",
 ]
 
 [tool.pytest.ini_options]

--- a/setup.py
+++ b/setup.py
@@ -70,4 +70,10 @@ setup(
     },
     include_package_data=True,
     ext_modules=ext_modules,
+    entry_points={
+        'console_scripts': [
+            'cim-spreadsheet=triplets.cli.cim_spreadsheet:main',
+            'cim-diff=triplets.cli.cim_diff:main',
+        ],
+    },
 )

--- a/triplets/__init__.py
+++ b/triplets/__init__.py
@@ -3,12 +3,14 @@ from . import export_schema
 from . import rdf_parser
 from . import cgmes_tools
 from . import rdfs_tools
+from . import cli
 
 __all__ = [
     'cgmes_tools',
     'rdf_parser',
     'export_schema',
-    'rdfs_tools'
+    'rdfs_tools',
+    'cli',
 ]
 
 from ._version import get_versions

--- a/triplets/cli/__init__.py
+++ b/triplets/cli/__init__.py
@@ -1,0 +1,5 @@
+"""
+CLI tools for the triplets package.
+"""
+
+__all__ = ['cim_spreadsheet', 'cim_diff']

--- a/triplets/cli/cim_diff.py
+++ b/triplets/cli/cim_diff.py
@@ -1,0 +1,203 @@
+"""
+CIM Diff Tool
+=============
+
+Command-line tool for comparing CIM XML (Common Information Model) files and
+displaying differences in unified diff format.
+
+This tool compares CIM files at the semantic level (object-by-object based on
+ID, KEY, VALUE triplets) rather than as plain XML text. This makes it much more
+useful for identifying actual data changes while ignoring irrelevant formatting
+or ordering differences.
+
+Installation
+------------
+Install the triplets package::
+
+    pip install triplets
+
+Or install from source::
+
+    git clone https://github.com/Haigutus/triplets.git
+    cd triplets
+    pip install -e .
+
+Using uv (recommended)::
+
+    uv pip install -e .
+
+Usage
+-----
+After installation, the tool can be invoked in three ways:
+
+1. **As a command-line tool** (recommended)::
+
+    cim-diff original.xml modified.xml
+
+2. **As a Python module**::
+
+    python -m triplets.tools.cim_diff_cli original.xml modified.xml
+
+3. **Programmatically** in Python code::
+
+    from triplets import rdf_parser
+
+    # Load both files
+    original = rdf_parser.load_all_to_dataframe(['original.xml'])
+    modified = rdf_parser.load_all_to_dataframe(['modified.xml'])
+
+    # Print diff
+    rdf_parser.print_triplet_diff(original, modified, exclude_objects=['NamespaceMap', 'Distribution'])
+
+Features
+--------
+- Semantic comparison at triplet level (ID, KEY, VALUE)
+- Unified diff format output for easy reading
+- Support for ZIP archives (single or nested)
+- Default exclusions for metadata objects (NamespaceMap, Distribution)
+- Custom exclusion lists for filtering out specific object types
+- Handles large CIM files efficiently
+
+Examples
+--------
+Basic diff between two CIM files::
+
+    $ cim-diff original.xml modified.xml
+
+Diff with custom exclusions::
+
+    $ cim-diff original.xml modified.xml -ex Terminal ConnectivityNode
+
+Diff without default exclusions::
+
+    $ cim-diff original.xml modified.xml --no-default-exclusions
+
+Diff between ZIP archives::
+
+    $ cim-diff original.zip modified.zip
+
+Add custom exclusions on top of defaults::
+
+    $ cim-diff original.xml modified.xml -ex CustomType1 CustomType2
+
+Output Format
+-------------
+The tool outputs differences in unified diff format::
+
+    --- Objects in original_file
+    +++ Objects in modified_file
+    - ObjectID ObjectType.attribute oldValue
+    + ObjectID ObjectType.attribute newValue
+
+Lines starting with '-' indicate values removed (in original but not in modified).
+Lines starting with '+' indicate values added (in modified but not in original).
+
+Default Exclusions
+------------------
+By default, the following object types are excluded from comparison as they
+typically contain auto-generated metadata that changes between exports:
+
+- NamespaceMap : XML namespace mappings (contains UUIDs)
+- Distribution : File distribution metadata
+
+Use --no-default-exclusions to include these in the comparison.
+
+See Also
+--------
+cim-spreadsheet : Tool for converting between CIM XML and spreadsheet formats
+triplets.rdf_parser.print_triplet_diff : Core diff function
+"""
+
+import sys
+import argparse
+from .. import rdf_parser
+
+def main():
+    """
+    CLI entry point for cim-diff tool.
+
+    Parses command-line arguments and executes comparison of two CIM XML files,
+    displaying differences in unified diff format.
+
+    Command-Line Usage
+    ------------------
+    Basic usage::
+
+        cim-diff original.xml modified.xml
+
+    With custom exclusions::
+
+        cim-diff original.xml modified.xml -ex Terminal ACLineSegment
+
+    Without default exclusions::
+
+        cim-diff original.xml modified.xml --no-default-exclusions
+
+    Combined exclusions::
+
+        cim-diff original.xml modified.xml -ex CustomType --no-default-exclusions
+
+    Parameters
+    ----------
+    original_file : str (positional)
+        Path to original CIM XML file or ZIP archive
+    changed_file : str (positional)
+        Path to modified CIM XML file or ZIP archive
+    -ex, --exclude_objects : list of str, optional
+        Object type names (without namespace/prefix) to exclude from diff.
+        These are added to default exclusions unless --no-default-exclusions is used.
+    --no-default-exclusions : flag, optional
+        Disable default exclusions (NamespaceMap, Distribution)
+
+    Exit Codes
+    ----------
+    0 : Successful comparison (differences shown on stdout)
+
+    Notes
+    -----
+    The diff is performed on the semantic triplet level (ID, KEY, VALUE),
+    not on raw XML text. This means:
+
+    - XML formatting differences are ignored
+    - Element ordering differences are ignored
+    - Only actual data value changes are shown
+    - Object type filtering happens before comparison
+
+    See Also
+    --------
+    triplets.rdf_parser.load_all_to_dataframe : Loads CIM XML into triplet format
+    triplets.rdf_parser.print_triplet_diff : Prints differences between triplet DataFrames
+    """
+    parser = argparse.ArgumentParser(
+        description="""Create diff in Unified format for XML RDF CIM files.
+        Diff is per object (ID KEY VALUE) not per XML line in file.
+        The input can be xml, zip(xml), zip(zip(xml))""",
+        epilog="""Copyright (c) Kristjan Vilgo 2026; Licence: MIT"""
+    )
+    parser.add_argument('original_file', type=str, help='Original file path')
+    parser.add_argument('changed_file', type=str, help='Changed file path')
+    parser.add_argument('-ex', '--exclude_objects', nargs='+', help='Names of rdf:Description rdf:type-s without namespace or prefix to be excluded from diff (default: NamespaceMap, Distribution)')
+    parser.add_argument('--no-default-exclusions', action='store_true', help='Disable default exclusions (NamespaceMap, Distribution)')
+
+    args = parser.parse_args()
+
+    # Default exclusions (typically objects that change due to UUIDs/metadata)
+    default_exclusions = ['NamespaceMap', 'Distribution']
+
+    # Determine final exclusion list
+    if args.no_default_exclusions:
+        exclude_objects = args.exclude_objects
+    else:
+        # Combine default exclusions with user-provided ones
+        exclude_objects = default_exclusions.copy()
+        if args.exclude_objects:
+            exclude_objects.extend(args.exclude_objects)
+
+    # Load and compare files
+    original_data = rdf_parser.load_all_to_dataframe([args.original_file])
+    changed_data = rdf_parser.load_all_to_dataframe([args.changed_file])
+
+    rdf_parser.print_triplet_diff(original_data, changed_data, exclude_objects=exclude_objects if exclude_objects else None)
+
+if __name__ == "__main__":
+    main()

--- a/triplets/cli/cim_spreadsheet.py
+++ b/triplets/cli/cim_spreadsheet.py
@@ -1,0 +1,632 @@
+"""
+CIM Spreadsheet Converter CLI Tool
+===================================
+
+Command-line tool for converting between CIM XML (Common Information Model) and
+spreadsheet formats (Excel/CSV).
+
+This tool provides bidirectional conversion:
+- **CIM to Spreadsheet**: Convert CIM XML files to Excel or CSV format
+- **Spreadsheet to CIM**: Convert Excel or CSV files back to CIM XML
+
+The tool automatically detects the conversion direction based on file extensions,
+making it simple to use without explicit direction specification.
+
+Installation
+------------
+Install the triplets package with optional dependencies::
+
+    pip install triplets[optional]
+
+Or install from source::
+
+    git clone https://github.com/Haigutus/triplets.git
+    cd triplets
+    pip install -e .[optional]
+
+Using uv (recommended)::
+
+    uv pip install -e .[optional]
+
+The ``optional`` extra includes ``openpyxl`` for Excel support.
+
+Usage
+-----
+After installation, the tool can be invoked in three ways:
+
+1. **As a command-line tool** (recommended)::
+
+    cim-spreadsheet -i input_file -o output_file
+
+2. **As a Python module**::
+
+    python -m triplets.tools.cim_spreadsheet_cli -i input_file -o output_file
+
+3. **Programmatically** in Python code::
+
+    from triplets.tools.cim_spreadsheet_cli import cim_to_spreadsheet, spreadsheet_to_cim
+
+    # Convert CIM to Excel
+    cim_to_spreadsheet('model.xml', 'output.xlsx')
+
+    # Convert Excel to CIM
+    spreadsheet_to_cim('data.xlsx', 'cim_output/')
+
+Examples
+--------
+Convert CIM XML to Excel::
+
+    cim-spreadsheet -i model.xml -o output.xlsx
+
+Convert CIM XML to CSV (auto-zipped)::
+
+    cim-spreadsheet -i model.xml -o output.zip -f csv
+
+Convert Excel back to CIM XML::
+
+    cim-spreadsheet -i output.xlsx -o cim_output/
+
+Disable multivalue mode (keep duplicate ID+KEY pairs as separate rows)::
+
+    cim-spreadsheet -i model.xml -o output.xlsx --no-multivalue
+
+Select specific sheets to convert::
+
+    cim-spreadsheet -i data.xlsx -o output/ --sheets ACLineSegment Substation
+
+Include raw triplets sheet::
+
+    cim-spreadsheet -i data.xlsx -o output/ --triplets-sheet RawData
+
+Explicitly specify conversion direction::
+
+    cim-spreadsheet -i model.xml -o output.xlsx -d to-spreadsheet
+
+Force ZIP output for Excel::
+
+    cim-spreadsheet -i model.xml -o output.zip -f excel -z
+
+Disable ZIP output for CSV::
+
+    cim-spreadsheet -i model.xml -o csv_dir/ -f csv --no-zip
+
+Features
+--------
+- Auto-detection of conversion direction from file extensions
+- Support for both Excel (.xlsx) and CSV formats
+- ZIP compression support for output files
+- Multivalue mode enabled by default (aggregates/unpacks duplicate ID+KEY pairs into lists)
+- Sheet/file selection for both Excel and CSV formats
+- Raw triplets import from dedicated Excel sheet or CSV file
+- Handles zipped input/output files automatically
+
+See Also
+--------
+cim-diff : Tool for comparing CIM XML files
+triplets.rdf_parser : Core module for RDF/CIM data manipulation
+"""
+
+import sys
+import os
+import argparse
+import logging
+import zipfile
+import pandas
+from io import BytesIO, StringIO
+from uuid import uuid4
+
+from .. import rdf_parser
+from ..export_schema import schemas
+
+def cim_to_spreadsheet(cim_path, output_path, format=None, zip_output=None, multivalue=True):
+    """
+    Convert CIM XML to spreadsheet format (Excel or CSV).
+
+    Handles all orchestration including file I/O, format detection, zipping,
+    and conversion through the core rdf_parser functions.
+
+    Parameters
+    ----------
+    cim_path : str
+        Path to input CIM XML file or ZIP containing XML files
+    output_path : str
+        Path to output file (for Excel/zipped CSV) or directory (for CSV)
+    format : {'excel', 'csv'}, optional
+        Output format. If None, auto-detected from output_path extension.
+        Defaults to 'excel' if ambiguous.
+    zip_output : bool, optional
+        Whether to ZIP the output. If None, defaults to True for CSV format,
+        False for Excel format.
+    multivalue : bool, default True
+        If True, aggregate duplicate (ID, KEY) pairs into lists in the output.
+        Use False to keep duplicate pairs as separate rows.
+
+    Raises
+    ------
+    ImportError
+        If openpyxl is not installed and Excel format is requested
+
+    Examples
+    --------
+    >>> cim_to_spreadsheet('model.xml', 'output.xlsx')
+    >>> cim_to_spreadsheet('model.zip', 'output.zip', format='csv')
+    >>> cim_to_spreadsheet('model.xml', 'output.xlsx', multivalue=True)
+    """
+
+    # Format detection
+    if format is None:
+        if output_path.endswith((".xlsx", ".xls")):
+            format = "excel"
+        elif output_path.endswith((".csv", ".zip")) or os.path.isdir(output_path):
+            format = "csv"
+        else:
+            format = "excel"
+
+    # Default zip behavior
+    if zip_output is None:
+        zip_output = (format == "csv")
+
+    data = rdf_parser.load_all_to_dataframe(cim_path)
+
+    base_name = os.path.basename(output_path).replace('.zip', '').replace('.xlsx', '').replace('.csv', '')
+    if not base_name:
+        base_name = 'export'
+
+    if format == "excel":
+        excel_file = data.export_to_excel(
+            export_to_memory=True,
+            multivalue=multivalue,
+            single_file=True,
+            filename=f"{base_name}.xlsx",
+            apply_formatting=True
+        )
+
+        if zip_output:
+            # Zip the Excel file
+            zip_path = output_path if output_path.endswith('.zip') else output_path + '.zip'
+            with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+                zf.writestr(excel_file.name, excel_file.getvalue())
+        else:
+            # Write directly to file
+            with open(output_path, 'wb') as f:
+                f.write(excel_file.getvalue())
+
+    elif format == "csv":
+        csv_files = data.export_to_csv(
+            export_to_memory=True,
+            multivalue=multivalue,
+            single_file=True,
+            base_filename=base_name
+        )
+
+        if zip_output:
+            # Zip all CSV files
+            zip_path = output_path if output_path.endswith('.zip') else output_path + '.zip'
+            with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+                for csv_file in csv_files:
+                    zf.writestr(csv_file.name, csv_file.getvalue())
+        else:
+            # Write to directory
+            os.makedirs(output_path, exist_ok=True)
+            for csv_file in csv_files:
+                csv_path = os.path.join(output_path, csv_file.name)
+                with open(csv_path, 'wb') as f:
+                    f.write(csv_file.getvalue())
+
+
+def spreadsheet_to_cim(input_path, output_path, format=None, rdf_map=None,
+                       export_type=None, multivalue=True, zip_output=None,
+                       sheets=None, triplets_sheet=None):
+    """
+    Convert spreadsheet format (Excel or CSV) to CIM XML.
+
+    Handles all orchestration including file I/O, format detection, unzipping,
+    sheet selection, raw triplets import, and conversion through core rdf_parser
+    functions.
+
+    Parameters
+    ----------
+    input_path : str
+        Path to input Excel file, CSV directory, or ZIP archive
+    output_path : str
+        Path to output directory where CIM XML files will be written
+    format : {'excel', 'csv'}, optional
+        Input format. If None, auto-detected from input_path extension.
+        Defaults to 'excel' if ambiguous.
+    rdf_map : str, optional
+        Path to RDF map JSON file for custom mappings during export
+    export_type : {'xml_per_instance', 'xml_per_instance_zip_per_all', 'xml_per_instance_zip_per_xml'}, optional
+        How to package the CIM XML output. If None, defaults to
+        'xml_per_instance_zip_per_all' if zip_output=True, else 'xml_per_instance'
+    multivalue : bool, default True
+        If True, unpack list values into separate triplets during conversion.
+        Use False to keep list values as-is in single triplets.
+    zip_output : bool, optional
+        Whether to ZIP the output. Defaults to True.
+    sheets : list of str, optional
+        Specific sheet/file names to convert. For Excel, these are sheet names.
+        For CSV, these are base filenames (without .csv extension).
+        If None, converts all sheets/files except triplets_sheet.
+    triplets_sheet : str, optional
+        Name of sheet/file containing raw triplets (ID, KEY, VALUE columns)
+        to include in the output. For Excel, this is a sheet name. For CSV,
+        this is a base filename (without .csv extension).
+        This sheet is not processed as tableview data.
+
+    Returns
+    -------
+    result
+        Export result from rdf_parser.export_to_cimxml()
+
+    Raises
+    ------
+    ImportError
+        If openpyxl is not installed and Excel format is specified
+    ValueError
+        If CSV format is used with a file (requires directory or ZIP)
+        If no Excel file found in ZIP archive
+        If triplets sheet is missing required columns
+
+    Examples
+    --------
+    >>> spreadsheet_to_cim('data.xlsx', 'output/')
+    >>> spreadsheet_to_cim('data.zip', 'output/', sheets=['ACLineSegment', 'Substation'])
+    >>> spreadsheet_to_cim('data.xlsx', 'output/', triplets_sheet='RawData')
+    """
+
+    # Format detection
+    if format is None:
+        if input_path.endswith((".xlsx", ".xls")):
+            format = "excel"
+        elif input_path.endswith((".csv", ".zip")) or os.path.isdir(input_path):
+            format = "csv"
+        else:
+            format = "excel"
+
+    tableviews = {}
+    raw_triplets = []
+
+    if format == "excel":
+        try:
+            # Check if it's a zipped Excel file (not just an xlsx which is also a zip)
+            if input_path.endswith('.zip') and zipfile.is_zipfile(input_path):
+                # Read from ZIP in memory
+                with zipfile.ZipFile(input_path, 'r') as zf:
+                    # Find the Excel file
+                    excel_filename = None
+                    for filename in zf.namelist():
+                        if filename.endswith(('.xlsx', '.xls')):
+                            excel_filename = filename
+                            break
+
+                    if not excel_filename:
+                        raise ValueError("No Excel file found in ZIP archive")
+
+                    # Read Excel file to BytesIO
+                    excel_bytes = BytesIO(zf.read(excel_filename))
+
+                    # Read sheets as tableviews
+                    excel_obj = pandas.ExcelFile(excel_bytes)
+                    _read_excel_sheets(excel_obj, tableviews, raw_triplets, sheets, triplets_sheet)
+            else:
+                # Read directly from file (including .xlsx files)
+                excel_obj = pandas.ExcelFile(input_path)
+                _read_excel_sheets(excel_obj, tableviews, raw_triplets, sheets, triplets_sheet)
+        except ImportError as e:
+            raise ImportError(
+                "openpyxl is required for Excel import. "
+                "Install it with: pip install openpyxl"
+            ) from e
+
+    elif format == "csv":
+        csv_dataframes = {}
+
+        if zipfile.is_zipfile(input_path):
+            # Read from ZIP
+            with zipfile.ZipFile(input_path, 'r') as zf:
+                for filename in zf.namelist():
+                    if filename.endswith('.csv'):
+                        sheet_name = os.path.basename(filename)[:-4]
+                        csv_content = zf.read(filename).decode('utf-8')
+                        csv_dataframes[sheet_name] = pandas.read_csv(StringIO(csv_content), index_col=0)
+        elif os.path.isdir(input_path):
+            # Read from directory
+            for filename in os.listdir(input_path):
+                if filename.endswith('.csv'):
+                    sheet_name = filename[:-4]
+                    csv_path = os.path.join(input_path, filename)
+                    csv_dataframes[sheet_name] = pandas.read_csv(csv_path, index_col=0)
+        else:
+            raise ValueError(f"CSV format requires a directory or ZIP file, got: {input_path}")
+
+        if triplets_sheet and triplets_sheet in csv_dataframes:
+            triplet_df = csv_dataframes.pop(triplets_sheet).reset_index()
+            _extract_raw_triplets(triplet_df, triplets_sheet, raw_triplets)
+
+        # Filter by sheet names if specified
+        if sheets is not None:
+            csv_dataframes = {k: v for k, v in csv_dataframes.items() if k in sheets}
+            for sheet_name in sheets:
+                if sheet_name not in csv_dataframes:
+                    logging.warning(f"CSV '{sheet_name}' not found, skipping")
+
+        tableviews.update(csv_dataframes)
+
+    data = rdf_parser.tableviews_to_triplet(tableviews, multivalue=multivalue)
+
+    if raw_triplets:
+        data = pandas.concat([data] + raw_triplets, ignore_index=True)
+
+    from triplets._version import get_versions
+    version = get_versions()['version']
+    tool_version = f"triplets-{version}"
+    # Old header (md:FullModel) uses Model.applicationSoftware
+    data.set_VALUE_at_KEY("Model.applicationSoftware", tool_version)
+    # New header (dcat:Dataset) uses applicationSoftware (eumd namespace)
+    data.set_VALUE_at_KEY("applicationSoftware", tool_version)
+
+    if "INSTANCE_ID" not in data.columns or data["INSTANCE_ID"].isna().all():
+        data["INSTANCE_ID"] = str(uuid4())
+
+    if zip_output is None:
+        zip_output = True
+
+    if export_type is None:
+        export_type = "xml_per_instance_zip_per_all" if zip_output else "xml_per_instance"
+
+    os.makedirs(output_path, exist_ok=True)
+
+    # Export to CIM XML
+    return rdf_parser.export_to_cimxml(
+        data,
+        rdf_map=rdf_map,
+        export_undefined=False,
+        export_type=export_type,
+        export_base_path=output_path,
+        debug=False
+    )
+
+
+def _extract_raw_triplets(df, source_name, raw_triplets):
+    """Validate and extract raw triplets from a DataFrame, appending to raw_triplets list."""
+    required = ["ID", "KEY", "VALUE"]
+    if all(col in df.columns for col in required):
+        raw_triplets.append(df[required])
+    else:
+        logging.warning(f"Triplets source '{source_name}' missing required columns (ID, KEY, VALUE), skipping")
+
+
+def _read_excel_sheets(excel_obj, tableviews, raw_triplets, sheets=None, triplets_sheet=None):
+    """
+    Read Excel sheets into tableviews dictionary and raw triplets list.
+
+    Internal helper function that populates tableviews and raw_triplets
+    dictionaries/lists by reading from an Excel file object.
+
+    Parameters
+    ----------
+    excel_obj : pandas.ExcelFile
+        Excel file object to read from
+    tableviews : dict
+        Dictionary to populate with {sheet_name: DataFrame} tableview data.
+        Modified in-place.
+    raw_triplets : list
+        List to populate with raw triplet DataFrames (ID, KEY, VALUE columns).
+        Modified in-place.
+    sheets : list of str, optional
+        Specific sheet names to read. If None, reads all sheets except
+        triplets_sheet.
+    triplets_sheet : str, optional
+        Name of sheet containing raw triplets (ID, KEY, VALUE columns).
+        This sheet is read separately and not included in tableviews.
+
+    Warnings
+    --------
+    - Logs warning if specified sheet not found in Excel file
+    - Logs warning if triplets sheet missing required columns (ID, KEY, VALUE)
+    """
+
+    # Determine which sheets to read
+    if sheets is None:
+        # Read all sheets except the triplets sheet
+        sheets_to_read = [s for s in excel_obj.sheet_names if s != triplets_sheet]
+    else:
+        sheets_to_read = sheets
+
+    valid_sheets = [s for s in sheets_to_read if s in excel_obj.sheet_names]
+    for s in sheets_to_read:
+        if s not in excel_obj.sheet_names:
+            logging.warning(f"Sheet '{s}' not found in Excel file, skipping")
+
+    if valid_sheets:
+        tableviews.update(pandas.read_excel(excel_obj, sheet_name=valid_sheets, index_col=0))
+
+    if triplets_sheet and triplets_sheet in excel_obj.sheet_names:
+        triplet_df = pandas.read_excel(excel_obj, sheet_name=triplets_sheet)
+        _extract_raw_triplets(triplet_df, triplets_sheet, raw_triplets)
+
+
+def detect_conversion_direction(input_path, output_path):
+    """
+    Auto-detect conversion direction from file extensions.
+
+    Examines input and output file paths to determine whether the conversion
+    should be CIM-to-spreadsheet or spreadsheet-to-CIM.
+
+    Parameters
+    ----------
+    input_path : str
+        Input file or directory path
+    output_path : str
+        Output file or directory path
+
+    Returns
+    -------
+    str
+        Either 'to-spreadsheet' or 'to-cim'
+
+    Raises
+    ------
+    ValueError
+        If conversion direction cannot be determined from file extensions
+
+    Notes
+    -----
+    Detection logic:
+
+    - If input is .xml/.rdf (or ZIP containing such files), direction is 'to-spreadsheet'
+    - If input is .xlsx/.xls/.csv (or directory with CSVs), direction is 'to-cim'
+    - If ambiguous from input, checks output path for spreadsheet extensions or
+      directory-like patterns
+    - Raises ValueError if direction cannot be determined
+
+    Examples
+    --------
+    >>> detect_conversion_direction('model.xml', 'output.xlsx')
+    'to-spreadsheet'
+    >>> detect_conversion_direction('data.xlsx', 'output/')
+    'to-cim'
+    """
+
+    # Check if input is CIM XML
+    input_is_cim = input_path.endswith(('.xml', '.rdf'))
+    if not input_is_cim and zipfile.is_zipfile(input_path):
+        with zipfile.ZipFile(input_path, 'r') as zf:
+            input_is_cim = any(f.endswith(('.xml', '.rdf')) for f in zf.namelist())
+
+    # Check if input is spreadsheet
+    input_is_spreadsheet = input_path.endswith(('.xlsx', '.xls', '.csv')) or (
+        os.path.isdir(input_path) and any(f.endswith('.csv') for f in os.listdir(input_path))
+    )
+
+    # Determine direction
+    if input_is_cim and not input_is_spreadsheet:
+        return 'to-spreadsheet'
+    elif input_is_spreadsheet and not input_is_cim:
+        return 'to-cim'
+    else:
+        # Ambiguous, check output
+        output_is_spreadsheet = output_path.endswith(('.xlsx', '.xls', '.csv'))
+        output_is_dir = os.path.isdir(output_path) or '/' in output_path or '\\' in output_path
+
+        if output_is_spreadsheet:
+            return 'to-spreadsheet'
+        elif output_is_dir:
+            return 'to-cim'
+        else:
+            raise ValueError(
+                "Cannot auto-detect conversion direction. "
+                "Please specify --direction (to-spreadsheet or to-cim)"
+            )
+
+
+def main():
+    """
+    CLI entry point for cim-spreadsheet tool.
+
+    Parses command-line arguments and executes the appropriate conversion
+    (CIM-to-spreadsheet or spreadsheet-to-CIM) with auto-detection of
+    conversion direction.
+
+    Command-Line Usage
+    ------------------
+    Basic conversion (auto-detect direction)::
+
+        cim-spreadsheet -i input_file -o output_file
+
+    Explicit direction::
+
+        cim-spreadsheet -i model.xml -o output.xlsx -d to-spreadsheet
+        cim-spreadsheet -i data.xlsx -o output/ -d to-cim
+
+    Format specification::
+
+        cim-spreadsheet -i model.xml -o output.zip -f csv
+        cim-spreadsheet -i data.zip -o output/ -f csv
+
+    Advanced options::
+
+        cim-spreadsheet -i model.xml -o output.xlsx --no-multivalue  # disable multivalue mode
+        cim-spreadsheet -i data.xlsx -o output/ --sheets Sheet1 Sheet2
+        cim-spreadsheet -i data.xlsx -o output/ --triplets-sheet RawData
+        cim-spreadsheet -i model.xml -o output.xlsx -z  # force ZIP
+
+    Exit Codes
+    ----------
+    0 : Successful conversion
+    1 : Error during conversion (see stderr for details)
+
+    See Also
+    --------
+    cim_to_spreadsheet : Function for CIM to spreadsheet conversion
+    spreadsheet_to_cim : Function for spreadsheet to CIM conversion
+    detect_conversion_direction : Auto-detection logic
+    """
+    parser = argparse.ArgumentParser(
+        description="Convert between CIM XML and Spreadsheet (Excel/CSV) formats. "
+                    "Conversion direction is auto-detected from file extensions."
+    )
+
+    # Common arguments
+    parser.add_argument("--input", "-i", required=True, help="Input file or directory")
+    parser.add_argument("--output", "-o", required=True, help="Output file or directory")
+    parser.add_argument("--direction", "-d", choices=["to-spreadsheet", "to-cim"], help="Conversion direction (auto-detected if not specified)")
+    parser.add_argument("--format", "-f", choices=["excel", "csv"], help="Spreadsheet format (auto-detected if not specified)")
+    parser.add_argument("--no-multivalue", action="store_false", dest="multivalue", help="Disable multivalue mode (keep duplicate (ID, KEY) pairs as separate rows/triplets instead of aggregating into lists)")
+    parser.set_defaults(multivalue=True)
+    parser.add_argument("--zip", "-z", action="store_true", dest="zip_output", help="Zip output")
+    parser.add_argument("--no-zip", action="store_false", dest="zip_output", help="Do not zip output")
+    parser.set_defaults(zip_output=None)
+
+    # Spreadsheet to CIM specific arguments
+    parser.add_argument("--rdf-map", "-r", help="Path to RDF map JSON (for to-cim conversion)")
+    parser.add_argument("--export-type", "-e", choices=["xml_per_instance", "xml_per_instance_zip_per_all", "xml_per_instance_zip_per_xml"], help="How to package CIM XML export (for to-cim conversion)")
+    parser.add_argument("--sheets", "-s", nargs='+', help="Specific sheet/file names to convert (Excel sheet names or CSV base filenames)")
+    parser.add_argument("--triplets-sheet", "-t", help="Sheet/file name containing raw triplets (ID, KEY, VALUE) to include (Excel sheet name or CSV base filename)")
+
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+
+    # Detect conversion direction if not specified
+    direction = args.direction
+    if direction is None:
+        try:
+            direction = detect_conversion_direction(args.input, args.output)
+            logging.info(f"Auto-detected conversion direction: {direction}")
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    try:
+        if direction == "to-spreadsheet":
+            cim_to_spreadsheet(
+                args.input,
+                args.output,
+                format=args.format,
+                zip_output=args.zip_output,
+                multivalue=args.multivalue
+            )
+            print(f"Converted {args.input} → {args.output}")
+
+        elif direction == "to-cim":
+            spreadsheet_to_cim(
+                args.input,
+                args.output,
+                format=args.format,
+                rdf_map=args.rdf_map,
+                export_type=args.export_type,
+                multivalue=args.multivalue,
+                zip_output=args.zip_output,
+                sheets=args.sheets,
+                triplets_sheet=args.triplets_sheet
+            )
+            print(f"Converted {args.input} → {args.output}")
+
+    except Exception as e:
+        logging.exception("Error during conversion")
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/triplets/rdf_parser.py
+++ b/triplets/rdf_parser.py
@@ -390,7 +390,7 @@ def load_all_to_dataframe(list_of_paths_to_zip_globalzip_xml, debug=False, data_
 pandas.read_RDF = load_all_to_dataframe
 
 
-def type_tableview(data, type_name, string_to_number=True, type_key="Type"):
+def type_tableview(data, type_name, string_to_number=True, type_key="Type", multivalue=False):
     """Create a table view of all objects of a specified type.
 
     Parameters
@@ -403,6 +403,8 @@ def type_tableview(data, type_name, string_to_number=True, type_key="Type"):
         If True, convert columns containing numbers to numeric types (default is True).
     type_key : str, optional
         Key used to identify object types in the dataset (default is 'Type').
+    multivalue : bool, optional
+        If True, aggregate duplicate (ID, KEY) pairs into lists (default is False).
 
     Returns
     -------
@@ -411,7 +413,7 @@ def type_tableview(data, type_name, string_to_number=True, type_key="Type"):
 
     Examples
     --------
-    >>> table = data.type_tableview("ACLineSegment")
+    >>> table = data.type_tableview("ACLineSegment", multivalue=True)
     """
     # Get all ID-s of rows where Type == type_name
     type_id = data[(data["VALUE"] == type_name) & (data["KEY"] == type_key)]
@@ -421,14 +423,22 @@ def type_tableview(data, type_name, string_to_number=True, type_key="Type"):
         return None
 
     # Filter original data by found type_id data
-    # There can't be duplicate ID and KEY pairs for pivot, but this will lose data on full model DependantOn and other info, solution would be to use pivot table function.
-    type_data = pandas.merge(type_id[["ID"]], data, on="ID").drop_duplicates(["ID", "KEY"])
+    type_data = pandas.merge(type_id[["ID"]], data, on="ID")
 
-    # Convert form triplets to a table view all objects of same type
-    data_view = type_data.pivot(index="ID", columns="KEY")["VALUE"]
+    # Convert from triplets to a table view of all objects of same type
+    if multivalue:
+        def _aggregate(x):
+            x_list = list(x)
+            if len(x_list) == 1:
+                return x_list[0]
+            return x_list
+
+        data_view = type_data.pivot_table(index="ID", columns="KEY", values="VALUE", aggfunc=_aggregate)
+    else:
+        type_data = type_data.drop_duplicates(["ID", "KEY"])
+        data_view = type_data.pivot(index="ID", columns="KEY")["VALUE"]
 
     if string_to_number:
-        # Convert to data type to numeric in columns that contain only numbers (for easier data usage later on)
         for column in data_view.columns:
             try:
                 data_view[column] = pandas.to_numeric(data_view[column], errors="raise")
@@ -957,68 +967,225 @@ def set_VALUE_at_KEY_and_ID(data, key, value, id):
 # Extend this functionality to pandas DataFrame
 pandas.DataFrame.set_VALUE_at_KEY_and_ID = set_VALUE_at_KEY_and_ID
 
-# TODO - add CSV export
-def export_to_excel(data, path=None):
-    """Export triplet data to an Excel file, with each type on a separate sheet.
+def export_to_excel(data, path=None, multivalue=True, export_to_memory=False, single_file=False, filename=None, apply_formatting=True):
+    """Export triplet data to Excel file(s), with each type on a separate sheet.
 
     Parameters
     ----------
     data : pandas.DataFrame
         Triplet dataset containing RDF data.
     path : str, optional
-        Directory path to save the Excel file (default is current working directory).
+        Directory path to save Excel file(s), or file path when single_file=True.
+    multivalue : bool, default True
+        If True, aggregate duplicate (ID, KEY) pairs into lists.
+    export_to_memory : bool, default False
+        If True, return BytesIO objects; if False, save to disk.
+    single_file : bool, default False
+        If True, export all data to a single file instead of one file per INSTANCE_ID.
+    filename : str, optional
+        Filename to use when single_file=True. If None, uses 'export.xlsx'.
+    apply_formatting : bool, default True
+        If True, apply column width and freeze panes formatting.
 
-    Notes
-    -----
-    - Uses 'label' key to determine the filename for each INSTANCE_ID.
-    - Each object type is exported to a separate sheet.
-    - TODO: Add support for XlsxWriter properties for better formatting.
-
-    Examples
-    --------
-    >>> data.export_to_excel("output_dir")
+    Returns
+    -------
+    BytesIO, str, or list
+        Depends on single_file and export_to_memory flags.
     """
-    # TODO set some nice properties - https://xlsxwriter.readthedocs.io/workbook.html#workbook-set-properties
+    from io import BytesIO
 
-    labels = data.query("KEY == 'label'").iterrows()
-    # TODO dont use iterrows
-    # TODO instead of label use Distribution
-    for _, label in labels:
-        instance_data = data[data.INSTANCE_ID == label.INSTANCE_ID]
+    if single_file:
+        if filename is None:
+            filename = 'export.xlsx'
 
-        types = instance_data.types_dict()
+        tableviews = triplet_to_tableviews(data, multivalue=multivalue)
+        output = BytesIO()
+        output.name = filename
 
-        file_name = '{}.xlsx'.format(label.VALUE.split(".")[0])
+        with pandas.ExcelWriter(output, engine='openpyxl') as writer:
+            for class_type, class_data in tableviews.items():
+                class_data.to_excel(writer, sheet_name=class_type)
+                if apply_formatting:
+                    from openpyxl.utils import get_column_letter
+                    sheet = writer.sheets[class_type]
+                    for i in range(1, len(class_data.columns) + 2):
+                        sheet.column_dimensions[get_column_letter(i)].width = 38
+                    sheet.freeze_panes = 'B2'
 
-        if path is None:
-            path = os.getcwd()
+        output.seek(0)
 
-        file_path = os.path.join(path, file_name)
+        if export_to_memory:
+            return output
+        else:
+            if path is None:
+                path = os.getcwd()
+            if os.path.isdir(path) or not path.endswith('.xlsx'):
+                export_path = os.path.join(path, filename)
+            else:
+                export_path = path
+            with open(export_path, 'wb') as f:
+                f.write(output.read())
+            logger.info(f'Saved {export_path}')
+            return filename
+    else:
+        labels = data.query("KEY == 'label'")
+        exported_files = []
 
-        logger.info("Exporting excel: {}".format(file_path))
-        writer = pandas.ExcelWriter(file_path)
+        for _, label in labels.iterrows():
+            instance_data = data[data.INSTANCE_ID == label.INSTANCE_ID]
+            tableviews = triplet_to_tableviews(instance_data, multivalue=multivalue)
+            file_name = '{}.xlsx'.format(label.VALUE.split(".")[0])
+            output = BytesIO()
+            output.name = file_name
 
-        for class_type in types:
-            class_data = instance_data.type_tableview(class_type)
-            class_data.to_excel(writer, class_type)
+            with pandas.ExcelWriter(output, engine='openpyxl') as writer:
+                for class_type, class_data in tableviews.items():
+                    class_data.to_excel(writer, sheet_name=class_type)
+                    if apply_formatting:
+                        from openpyxl.utils import get_column_letter
+                        sheet = writer.sheets[class_type]
+                        for i in range(1, len(class_data.columns) + 2):
+                            sheet.column_dimensions[get_column_letter(i)].width = 38
+                        sheet.freeze_panes = 'B2'
 
-            # Get sheet to do some formatting
-            sheet = writer.sheets[class_type]
+            output.seek(0)
+            exported_files.append(output)
 
-            # Set default column size, if this does not work you are missing XslxWriter module
-            first_col = 0
-            last_col = len(class_data.columns)
-            width = 38
-            sheet.set_column(first_col, last_col, width)
-
-            # freeze column names and ID column
-            sheet.freeze_panes(1, 1)
-
-        writer.save()
+        if export_to_memory:
+            return exported_files
+        else:
+            if path is None:
+                path = os.getcwd()
+            exported_file_names = []
+            for file_object in exported_files:
+                export_path = os.path.join(path, file_object.name)
+                with open(export_path, 'wb') as f:
+                    file_object.seek(0)
+                    f.write(file_object.read())
+                exported_file_names.append(file_object.name)
+                logger.info(f'Saved {export_path}')
+            return exported_file_names
 
 
 # Extend this functionality to pandas DataFrame
 pandas.DataFrame.export_to_excel = export_to_excel
+
+
+def export_to_csv(data, path=None, multivalue=True, export_to_memory=False, single_file=False, base_filename=None):
+    """Export triplet data to CSV files, with each type as a separate file.
+
+    Parameters
+    ----------
+    data : pandas.DataFrame
+        Triplet dataset containing RDF data.
+    path : str, optional
+        Directory path to save CSV file(s).
+    multivalue : bool, default True
+        If True, aggregate duplicate (ID, KEY) pairs into lists.
+    export_to_memory : bool, default False
+        If True, return BytesIO objects; if False, save to disk.
+    single_file : bool, default False
+        If True, export all data using a single base filename.
+    base_filename : str, optional
+        Base filename when single_file=True. If None, uses 'export'.
+    """
+    from io import BytesIO
+
+    if single_file:
+        if base_filename is None:
+            base_filename = 'export'
+        tableviews = triplet_to_tableviews(data, multivalue=multivalue)
+        exported_files = []
+        for class_type, class_data in tableviews.items():
+            file_name = '{}_{}.csv'.format(base_filename, class_type)
+            output = BytesIO()
+            output.name = file_name
+            output.write(class_data.to_csv().encode('utf-8'))
+            output.seek(0)
+            exported_files.append(output)
+    else:
+        labels = data.query("KEY == 'label'")
+        exported_files = []
+        for _, label in labels.iterrows():
+            instance_data = data[data.INSTANCE_ID == label.INSTANCE_ID]
+            tableviews = triplet_to_tableviews(instance_data, multivalue=multivalue)
+            base_name = label.VALUE.split(".")[0]
+            for class_type, class_data in tableviews.items():
+                file_name = '{}_{}.csv'.format(base_name, class_type)
+                output = BytesIO()
+                output.name = file_name
+                output.write(class_data.to_csv().encode('utf-8'))
+                output.seek(0)
+                exported_files.append(output)
+
+    if export_to_memory:
+        return exported_files
+    else:
+        if path is None:
+            path = os.getcwd()
+        exported_file_names = []
+        for file_object in exported_files:
+            export_path = os.path.join(path, file_object.name)
+            with open(export_path, 'wb') as f:
+                file_object.seek(0)
+                f.write(file_object.read())
+            exported_file_names.append(file_object.name)
+            logger.info(f'Saved {export_path}')
+        return exported_file_names
+
+
+pandas.DataFrame.export_to_csv = export_to_csv
+
+
+def triplet_to_tableviews(triplet_df, multivalue=False):
+    """Convert triplet DataFrame to dict of tableview DataFrames.
+
+    Parameters
+    ----------
+    triplet_df : pandas.DataFrame
+        Triplet dataset with columns [ID, KEY, VALUE, INSTANCE_ID].
+    multivalue : bool, default False
+        If True, aggregate duplicate (ID, KEY) pairs into lists.
+
+    Returns
+    -------
+    dict
+        {class_name: tableview_df}
+    """
+    types = triplet_df.types_dict()
+    tableviews = {}
+    for class_name in types:
+        table_view = triplet_df.type_tableview(class_name, multivalue=multivalue)
+        if table_view is not None:
+            tableviews[class_name] = table_view
+    return tableviews
+
+
+def tableviews_to_triplet(tableviews, multivalue=False):
+    """Convert dict of tableview DataFrames to triplet DataFrame.
+
+    Parameters
+    ----------
+    tableviews : dict
+        {class_name: tableview_df}
+    multivalue : bool, default False
+        If True, unpack list values into separate triplets.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Triplet DataFrame with columns [ID, KEY, VALUE, INSTANCE_ID].
+    """
+    all_triplets = []
+    for class_name, df in tableviews.items():
+        if 'Type' not in df.columns:
+            df = df.assign(Type=class_name)
+        triplet = df.tableview_to_triplet(multivalue=multivalue)
+        triplet = triplet[triplet['VALUE'].notna()]
+        all_triplets.append(triplet)
+    if not all_triplets:
+        return pandas.DataFrame(columns=['ID', 'KEY', 'VALUE', 'INSTANCE_ID'])
+    return pandas.concat(all_triplets, ignore_index=True)
 
 
 @lru_cache(maxsize=250)  # Adjust maxsize based on the number of unique QName combinations
@@ -1530,29 +1697,39 @@ def get_object_data(data, object_UUID):
 pandas.DataFrame.get_object_data = get_object_data
 
 
-def tableview_to_triplet(data):
+def tableview_to_triplet(data, multivalue=False):
     """Convert a table view back to a triplet format.
 
     Parameters
     ----------
     data : pandas.DataFrame
         Pivoted DataFrame (table view) to convert.
+    multivalue : bool, optional
+        If True, unpack list values into separate triplets (default is False).
 
     Returns
     -------
     pandas.DataFrame
         Triplet DataFrame with columns ['ID', 'KEY', 'VALUE'].
-
-    Notes
-    -----
-    - TODO: Ensure this is only used on valid table views.
-
-    Examples
-    --------
-    >>> triplet = tableview_to_triplet(table_view)
     """
-    # TODO add only when tableveiw is created
-    return data.reset_index().melt(id_vars="ID", value_name="VALUE", var_name="KEY").astype(str)
+    triplet_df = data.reset_index().melt(id_vars="ID", value_name="VALUE", var_name="KEY")
+
+    if multivalue:
+        import ast
+        def _ensure_list(val):
+            if isinstance(val, str) and val.startswith("[") and val.endswith("]"):
+                try:
+                    parsed = ast.literal_eval(val)
+                    if isinstance(parsed, list):
+                        return parsed
+                except (ValueError, SyntaxError):
+                    pass
+            return val
+
+        triplet_df["VALUE"] = triplet_df["VALUE"].apply(_ensure_list)
+        triplet_df = triplet_df.explode("VALUE")
+
+    return triplet_df.astype(str)
 
 
 pandas.DataFrame.tableview_to_triplet = tableview_to_triplet


### PR DESCRIPTION
## Summary

Cherry-picks the CIM spreadsheet conversion feature from `feat/cim-spreadsheet-conversion`, adapted to work with the three-tier parser architecture on main.

### New: CLI tools
- **cim-spreadsheet**: Bidirectional CIM XML <-> Excel/CSV conversion with auto-detection
- **cim-diff**: Semantic diff between CIM datasets with configurable exclusions

### New: Functions in rdf_parser.py
- `export_to_csv()` — export triplets to CSV files (one per type)
- `triplet_to_tableviews()` — convert triplet DataFrame to dict of tableview DataFrames
- `tableviews_to_triplet()` — convert dict of tableviews back to triplet DataFrame

### Enhanced: Existing functions
- `type_tableview(multivalue=)` — aggregate duplicate (ID, KEY) pairs into lists
- `export_to_excel(multivalue=, export_to_memory=, single_file=, apply_formatting=)` — full rewrite with openpyxl
- `tableview_to_triplet(multivalue=)` — unpack list values into separate triplets

### New: Entry points
- `cim-spreadsheet` and `cim-diff` CLI commands (install with `pip install triplets`)

### New: Optional dependency
- `openpyxl` for Excel support (`pip install triplets[excel]`)
- Supports both old (md:FullModel) and new (dcat:Dataset) header formats

## Test plan
- [x] All 30 existing parser tests pass
- [x] No performance regression (cython engine: 117ms on RealGrid)
- [x] New functions verified: triplet_to_tableviews, tableviews_to_triplet, multivalue roundtrip
- [x] CLI imports work