### PR TITLE
ci: skip-existing on PyPI publish so partial publishes can be re-run

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -127,3 +127,6 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # don't fail re-runs on files a previous partial publish already uploaded
+          skip-existing: true


### PR DESCRIPTION
The rc2 publish failed twice: first the dirty sdist was rejected after
all 12 wheels had already uploaded, then the re-run died on "File
already exists" for the first wheel. With skip-existing the re-run
would have uploaded just the missing sdist.
