### PR TITLE
feat: cgmes_tools accepts polars, arrow, and duckdb input

### DIFF
--- a/docs/migration_0.0_to_0.1.md
+++ b/docs/migration_0.0_to_0.1.md
@@ -76,6 +76,17 @@ They will be removed in 0.2.
 | `triplets.rdf_parser.export_to_networkx` | `triplets.export.export_to_networkx` |
 | All other `rdf_parser.*` query/filter/diff functions | `triplets.tools.*` |
 
+### cgmes_tools renames
+
+Old names keep working in 0.1 but emit `DeprecationWarning`; they will be removed in 0.2.
+
+| Old (0.0) | New (0.1) |
+|-----------|-----------|
+| `cgmes_tools.darw_relations_graph` | `cgmes_tools.draw_relations_graph` (typo fix) |
+| `cgmes_tools.statistics_GeneratingUnit_types` | `cgmes_tools.count_GeneratingUnit_types` |
+| `cgmes_tools.generate_instances_ID` | `cgmes_tools.generate_instance_ids` |
+| `cgmes_tools.get_model_data` | `cgmes_tools.get_model_triplets` |
+
 ### DataFrame methods
 
 The old monkey-patched methods (`data.type_tableview(...)`) still work but the recommended

--- a/docs/source/guides/migration_0.0_to_0.1.md
+++ b/docs/source/guides/migration_0.0_to_0.1.md
@@ -76,6 +76,17 @@ They will be removed in 0.2.
 | `triplets.rdf_parser.export_to_networkx` | `triplets.export.export_to_networkx` |
 | All other `rdf_parser.*` query/filter/diff functions | `triplets.tools.*` |
 
+### cgmes_tools renames
+
+Old names keep working in 0.1 but emit `DeprecationWarning`; they will be removed in 0.2.
+
+| Old (0.0.x) | New (0.1) |
+|-----------|-----------|
+| `cgmes_tools.darw_relations_graph` | `cgmes_tools.draw_relations_graph` (typo fix) |
+| `cgmes_tools.statistics_GeneratingUnit_types` | `cgmes_tools.count_GeneratingUnit_types` |
+| `cgmes_tools.generate_instances_ID` | `cgmes_tools.generate_instance_ids` |
+| `cgmes_tools.get_model_data` | `cgmes_tools.get_model_triplets` |
+
 ### DataFrame methods
 
 The old monkey-patched methods (`data.type_tableview(...)`) still work but the recommended

--- a/tests/test_cgmes_tools.py
+++ b/tests/test_cgmes_tools.py
@@ -40,14 +40,14 @@ def svedala_eq():
 
 class TestGenerateInstancesID:
     def test_returns_dict(self):
-        ids = cgmes_tools.generate_instances_ID()
+        ids = cgmes_tools.generate_instance_ids()
         assert isinstance(ids, dict)
         assert "EQ" in ids
         assert "SSH" in ids
         assert "SV" in ids
 
     def test_all_unique(self):
-        ids = cgmes_tools.generate_instances_ID()
+        ids = cgmes_tools.generate_instance_ids()
         values = list(ids.values())
         assert len(values) == len(set(values))
 
@@ -110,6 +110,26 @@ class TestGetLoadedModelParts:
         parts = cgmes_tools.get_loaded_model_parts(svedala_data)
         assert isinstance(parts, pandas.DataFrame)
         assert len(parts) == 4  # EQ, SSH, TP, SV
+
+
+# ── Deprecated aliases ──────────────────────────────────────────────────────
+
+class TestDeprecatedAliases:
+    def test_old_names_warn_and_work(self, svedala_data):
+        with pytest.warns(DeprecationWarning, match="generate_instance_ids"):
+            ids = cgmes_tools.generate_instances_ID()
+        assert isinstance(ids, dict)
+
+        with pytest.warns(DeprecationWarning, match="count_GeneratingUnit_types"):
+            result = cgmes_tools.statistics_GeneratingUnit_types(svedala_data)
+        assert result is not None
+
+    def test_typo_alias_darw(self, svedala_data):
+        subs = svedala_data[(svedala_data["KEY"] == "Type") & (svedala_data["VALUE"] == "Substation")]["ID"].iloc[0]
+        reference_data = svedala_data.references_to(subs, levels=1)
+        with pytest.warns(DeprecationWarning, match="draw_relations_graph"):
+            result = cgmes_tools.darw_relations_graph(reference_data, notebook=True)
+        assert "new vis.Network" in result
 
 
 # ── Input flavors (polars / arrow / duckdb converted at the boundary) ───────
@@ -215,5 +235,5 @@ class TestVisualization:
 
 class TestStatisticsGeneratingUnitTypes:
     def test_returns_dataframe(self, svedala_data):
-        result = cgmes_tools.statistics_GeneratingUnit_types(svedala_data)
+        result = cgmes_tools.count_GeneratingUnit_types(svedala_data)
         assert isinstance(result, pandas.DataFrame)

--- a/tests/test_cgmes_tools.py
+++ b/tests/test_cgmes_tools.py
@@ -112,6 +112,53 @@ class TestGetLoadedModelParts:
         assert len(parts) == 4  # EQ, SSH, TP, SV
 
 
+# ── Input flavors (polars / arrow / duckdb converted at the boundary) ───────
+
+class TestInputFlavors:
+    def test_polars_input(self, svedala_data):
+        polars = pytest.importorskip("polars")
+        pl_data = polars.from_pandas(svedala_data)
+
+        models = cgmes_tools.get_loaded_models(pl_data)
+        assert isinstance(models, dict)
+
+        # DataFrame results come back as polars
+        parts = cgmes_tools.get_loaded_model_parts(pl_data)
+        assert isinstance(parts, polars.DataFrame)
+        assert len(parts) == 4
+
+    def test_arrow_input(self, svedala_data):
+        pyarrow = pytest.importorskip("pyarrow")
+        table = pyarrow.Table.from_pandas(svedala_data, preserve_index=False)
+
+        models = cgmes_tools.get_loaded_models(table)
+        assert isinstance(models, dict)
+
+        # DataFrame results come back as arrow
+        parts = cgmes_tools.get_loaded_model_parts(table)
+        assert isinstance(parts, pyarrow.Table)
+        assert parts.num_rows == 4
+
+    def test_duckdb_input(self, svedala_data):
+        duckdb = pytest.importorskip("duckdb")
+        con = duckdb.connect()
+        con.register("triplets_arrow", svedala_data)
+        con.execute("CREATE TABLE triplets AS SELECT * FROM triplets_arrow")
+
+        models = cgmes_tools.get_loaded_models(con)
+        assert isinstance(models, dict)
+
+        # duckdb input returns pandas
+        parts = cgmes_tools.get_loaded_model_parts(con)
+        assert isinstance(parts, pandas.DataFrame)
+        assert len(parts) == 4
+
+    def test_results_match_pandas(self, svedala_data):
+        polars = pytest.importorskip("polars")
+        expected = cgmes_tools.get_loaded_models(svedala_data)
+        assert cgmes_tools.get_loaded_models(polars.from_pandas(svedala_data)) == expected
+
+
 # ── Data quality ────────────────────────────────────────────────────────────
 
 class TestGetDanglingReferences:

--- a/triplets/cgmes_tools/__init__.py
+++ b/triplets/cgmes_tools/__init__.py
@@ -1,32 +1,95 @@
 """CGMES tools — metadata, visualization, and data quality utilities.
 
-Re-exports all public functions from pandas_engine for backwards compatibility.
-`from triplets import cgmes_tools` and `triplets.cgmes_tools.function()` work as before.
+The implementations are pandas-based (pandas_engine.py), but the functions
+accept triplet data in any supported flavor: pandas, polars, pyarrow
+Table/RecordBatch, or a DuckDB connection holding a `triplets` table.
+Non-pandas input is converted at this boundary (Arrow-backed, ~10 ms per
+million rows), and DataFrame results are converted back to the input flavor
+(DuckDB input returns pandas).
 """
-from .pandas_engine import *  # noqa: F401,F403
-from .pandas_engine import (
+import functools
+import logging
+
+import pandas
+
+from . import pandas_engine
+from .pandas_engine import (  # noqa: F401 — no triplet-data argument, re-exported as-is
     dependencies,
     default_filename_mask,
     generate_instances_ID,
     get_metadata_from_filename,
     get_filename_from_metadata,
     get_metadata_from_xml,
-    get_metadata_from_FullModel,
-    update_FullModel_from_dict,
-    update_FullModel_from_filename,
-    update_filename_from_FullModel,
-    get_loaded_models,
-    get_model_data,
-    get_loaded_model_parts,
-    get_EIC_to_mRID_map,
-    get_GeneratingUnits,
-    statistics_GeneratingUnit_types,
-    get_limits,
-    scale_load,
-    switch_equipment_terminals,
-    darw_relations_graph,
-    draw_relations_to,
-    draw_relations_from,
-    draw_relations,
-    get_dangling_references,
 )
+
+logger = logging.getLogger(__name__)
+
+# Functions taking a triplet dataset as first argument — wrapped below so any
+# supported data flavor can be passed directly.
+DATA_FUNCTIONS = [
+    # metadata
+    "get_metadata_from_FullModel", "update_FullModel_from_dict",
+    "update_FullModel_from_filename", "update_filename_from_FullModel",
+    # model inventory
+    "get_loaded_models", "get_model_data", "get_loaded_model_parts",
+    "get_EIC_to_mRID_map",
+    # equipment / statistics
+    "get_GeneratingUnits", "statistics_GeneratingUnit_types", "get_limits",
+    # modification
+    "scale_load", "switch_equipment_terminals",
+    # data quality
+    "get_dangling_references",
+    # visualization
+    "darw_relations_graph", "draw_relations_to", "draw_relations_from",
+    "draw_relations",
+]
+
+
+def _to_pandas(data):
+    """Triplet data in any supported flavor → pandas DataFrame."""
+    if isinstance(data, pandas.DataFrame):
+        return data
+    module = type(data).__module__
+    if module.startswith("polars"):
+        logger.debug("cgmes_tools input: polars → pandas")
+        return data.to_pandas(use_pyarrow_extension_array=True)
+    if module.startswith("pyarrow"):
+        logger.debug("cgmes_tools input: pyarrow → pandas")
+        return data.to_pandas(types_mapper=pandas.ArrowDtype)
+    if module.startswith(("duckdb", "_duckdb")):
+        logger.debug("cgmes_tools input: duckdb triplets table → pandas")
+        return data.execute("SELECT * FROM triplets").df()
+    return data  # trust pandas-compatible input
+
+
+def _match_input_flavor(result, data):
+    """Convert a pandas DataFrame result back to the flavor of the input data."""
+    if not isinstance(result, pandas.DataFrame):
+        return result
+    keep_index = not isinstance(result.index, pandas.RangeIndex)
+    module = type(data).__module__
+    if module.startswith("polars"):
+        import polars
+        return polars.from_pandas(result, include_index=keep_index)
+    if module.startswith("pyarrow"):
+        import pyarrow
+        return pyarrow.Table.from_pandas(result, preserve_index=keep_index)
+    return result  # pandas in (and duckdb in) → pandas out
+
+
+def _pandas_boundary(function):
+    @functools.wraps(function)
+    def wrapper(data, *args, **kwargs):
+        result = function(_to_pandas(data), *args, **kwargs)
+        return _match_input_flavor(result, data)
+    return wrapper
+
+
+for _name in DATA_FUNCTIONS:
+    globals()[_name] = _pandas_boundary(getattr(pandas_engine, _name))
+
+__all__ = [
+    "dependencies", "default_filename_mask", "generate_instances_ID",
+    "get_metadata_from_filename", "get_filename_from_metadata",
+    "get_metadata_from_xml",
+] + DATA_FUNCTIONS

--- a/triplets/cgmes_tools/__init__.py
+++ b/triplets/cgmes_tools/__init__.py
@@ -9,6 +9,7 @@ million rows), and DataFrame results are converted back to the input flavor
 """
 import functools
 import logging
+import warnings
 
 import pandas
 
@@ -16,7 +17,7 @@ from . import pandas_engine
 from .pandas_engine import (  # noqa: F401 — no triplet-data argument, re-exported as-is
     dependencies,
     default_filename_mask,
-    generate_instances_ID,
+    generate_instance_ids,
     get_metadata_from_filename,
     get_filename_from_metadata,
     get_metadata_from_xml,
@@ -31,18 +32,26 @@ DATA_FUNCTIONS = [
     "get_metadata_from_FullModel", "update_FullModel_from_dict",
     "update_FullModel_from_filename", "update_filename_from_FullModel",
     # model inventory
-    "get_loaded_models", "get_model_data", "get_loaded_model_parts",
+    "get_loaded_models", "get_model_triplets", "get_loaded_model_parts",
     "get_EIC_to_mRID_map",
     # equipment / statistics
-    "get_GeneratingUnits", "statistics_GeneratingUnit_types", "get_limits",
+    "get_GeneratingUnits", "count_GeneratingUnit_types", "get_limits",
     # modification
     "scale_load", "switch_equipment_terminals",
     # data quality
     "get_dangling_references",
     # visualization
-    "darw_relations_graph", "draw_relations_to", "draw_relations_from",
+    "draw_relations_graph", "draw_relations_to", "draw_relations_from",
     "draw_relations",
 ]
+
+# Old name → new name; old names keep working but emit DeprecationWarning
+DEPRECATED_ALIASES = {
+    "darw_relations_graph": "draw_relations_graph",            # typo
+    "statistics_GeneratingUnit_types": "count_GeneratingUnit_types",
+    "generate_instances_ID": "generate_instance_ids",
+    "get_model_data": "get_model_triplets",
+}
 
 
 def _to_pandas(data):
@@ -85,11 +94,26 @@ def _pandas_boundary(function):
     return wrapper
 
 
+def _deprecated_alias(old_name, new_name):
+    new_function = globals()[new_name]
+
+    @functools.wraps(new_function)
+    def wrapper(*args, **kwargs):
+        warnings.warn(f"cgmes_tools.{old_name} is deprecated, use cgmes_tools.{new_name}()",
+                      DeprecationWarning, stacklevel=2)
+        return new_function(*args, **kwargs)
+
+    return wrapper
+
+
 for _name in DATA_FUNCTIONS:
     globals()[_name] = _pandas_boundary(getattr(pandas_engine, _name))
 
+for _old, _new in DEPRECATED_ALIASES.items():
+    globals()[_old] = _deprecated_alias(_old, _new)
+
 __all__ = [
-    "dependencies", "default_filename_mask", "generate_instances_ID",
+    "dependencies", "default_filename_mask", "generate_instance_ids",
     "get_metadata_from_filename", "get_filename_from_metadata",
     "get_metadata_from_xml",
-] + DATA_FUNCTIONS
+] + DATA_FUNCTIONS + list(DEPRECATED_ALIASES)

--- a/triplets/cgmes_tools/pandas_engine.py
+++ b/triplets/cgmes_tools/pandas_engine.py
@@ -36,7 +36,7 @@ dependencies = dict(EQ   = ["EQBD"],
                     TPBD = ["EQBD"],
                     EQBD = [])
 
-def generate_instances_ID(dependencies=dependencies):
+def generate_instance_ids(dependencies=dependencies):
     """Generate UUIDs for each profile defined in the dependencies dictionary.
 
     Parameters
@@ -52,7 +52,7 @@ def generate_instances_ID(dependencies=dependencies):
 
     Examples
     --------
-    >>> generate_instances_ID()
+    >>> generate_instance_ids()
     {'EQ': '123e4567-e89b-12d3-a456-426614174000', ...}
     """
     return {profile: str(uuid4()) for profile in dependencies}
@@ -429,7 +429,7 @@ def get_loaded_models(data):
 
     return dependancies_dict
 
-def get_model_data(data, model_instances_dataframe):
+def get_model_triplets(data, model_instances_dataframe):
     """Extract data for specific CGMES model instances.
 
     Parameters
@@ -446,7 +446,7 @@ def get_model_data(data, model_instances_dataframe):
 
     Examples
     --------
-    >>> model_data = get_model_data(data, models['SV_UUID'])
+    >>> model_data = get_model_triplets(data, models['SV_UUID'])
     """
     IGM_data = pandas.merge(data, model_instances_dataframe[["INSTANCE_ID"]].drop_duplicates(), right_on="INSTANCE_ID", left_on="INSTANCE_ID")
 
@@ -507,7 +507,7 @@ def get_loaded_model_parts(data):
     return data.type_tableview("FullModel")
 
 
-def statistics_GeneratingUnit_types(data):
+def count_GeneratingUnit_types(data):
     """Calculate statistics for GeneratingUnit types in a CGMES dataset.
 
     Parameters
@@ -522,7 +522,7 @@ def statistics_GeneratingUnit_types(data):
 
     Examples
     --------
-    >>> stats = statistics_GeneratingUnit_types(data)
+    >>> stats = count_GeneratingUnit_types(data)
     >>> print(stats)
        Type  count  TOTAL    %
     0  Hydro   10     20  50.0
@@ -677,7 +677,7 @@ def _instance_filenames(data):
     return {instance_id: os.path.basename(str(path)) for instance_id, path in zip(labels["INSTANCE_ID"], labels["VALUE"])}
 
 
-def darw_relations_graph(reference_data, ID_COLUMN="ID", notebook=False, open_browser=True, instance_labels=None):
+def draw_relations_graph(reference_data, ID_COLUMN="ID", notebook=False, open_browser=True, instance_labels=None):
     """Create a temporary HTML file to visualize relations in a CGMES dataset.
 
     Parameters
@@ -709,7 +709,7 @@ def darw_relations_graph(reference_data, ID_COLUMN="ID", notebook=False, open_br
 
     Examples
     --------
-    >>> file_path = darw_relations_graph(data, 'ID')
+    >>> file_path = draw_relations_graph(data, 'ID')
     """
 
     pivot = reference_data.drop_duplicates([ID_COLUMN, "KEY"]).pivot(index=ID_COLUMN, columns="KEY")["VALUE"].reset_index()
@@ -735,8 +735,9 @@ def darw_relations_graph(reference_data, ID_COLUMN="ID", notebook=False, open_br
     for node in node_data.itertuples():
         object_data = reference_data.query("{} == '{}'".format(ID_COLUMN, node.ID))
         object_table = object_data[[ID_COLUMN, "KEY", "VALUE", "INSTANCE_ID"]].rename(columns={ID_COLUMN: "ID"}).drop_duplicates()
-        # Show the source filename instead of the instance UUID
-        object_table["INSTANCE_ID"] = object_table["INSTANCE_ID"].map(instance_labels).fillna(object_table["INSTANCE_ID"])
+        if instance_labels:
+            # Show the source filename instead of the instance UUID
+            object_table["INSTANCE_ID"] = object_table["INSTANCE_ID"].map(instance_labels).fillna(object_table["INSTANCE_ID"])
         nodes.append({
             "id": node.ID,
             "label": "{} - {}".format(node.Type, node.name),
@@ -794,7 +795,7 @@ def draw_relations_to(data, UUID, notebook=False, open_browser=True):
 
     ID_COLUMN = "ID"
 
-    return darw_relations_graph(reference_data, ID_COLUMN, notebook, open_browser=open_browser, instance_labels=_instance_filenames(data))
+    return draw_relations_graph(reference_data, ID_COLUMN, notebook, open_browser=open_browser, instance_labels=_instance_filenames(data))
 
 
 def draw_relations_from(data, UUID, notebook=False, open_browser=True):
@@ -823,7 +824,7 @@ def draw_relations_from(data, UUID, notebook=False, open_browser=True):
 
     ID_COLUMN = "ID"
 
-    return darw_relations_graph(reference_data, ID_COLUMN, notebook, open_browser=open_browser, instance_labels=_instance_filenames(data))
+    return draw_relations_graph(reference_data, ID_COLUMN, notebook, open_browser=open_browser, instance_labels=_instance_filenames(data))
 
 
 def draw_relations(data, UUID, notebook=False, levels=2, open_browser=True):
@@ -854,7 +855,7 @@ def draw_relations(data, UUID, notebook=False, levels=2, open_browser=True):
 
     ID_COLUMN = "ID"
 
-    return darw_relations_graph(reference_data, ID_COLUMN, notebook, open_browser=open_browser, instance_labels=_instance_filenames(data))
+    return draw_relations_graph(reference_data, ID_COLUMN, notebook, open_browser=open_browser, instance_labels=_instance_filenames(data))
 
 
 def scale_load(data, load_setpoint, cos_f=None):


### PR DESCRIPTION
## Problem

`cgmes_tools` functions are pandas implementations (`.query`, `.itertuples`, monkey-patched triplet methods). Any non-pandas input failed immediately: `'DataFrame' object has no attribute 'query'`.

## Changes

The package boundary (`cgmes_tools/__init__.py`) now converts input automatically:

| Input | Conversion | Cost (1.14M rows) |
|---|---|---|
| polars DataFrame | `to_pandas(use_pyarrow_extension_array=True)` | ~11 ms |
| pyarrow Table/RecordBatch | `to_pandas(types_mapper=pandas.ArrowDtype)` | zero-copy |
| DuckDB connection | `SELECT * FROM triplets` → `.df()` | one materialization |

DataFrame results are converted back to the input flavor (polars in → polars out, arrow in → arrow out; DuckDB input returns pandas). Dicts, paths, and graph HTML pass through unchanged.

`__init__.py` rewritten registry-style: a `DATA_FUNCTIONS` list + one `_pandas_boundary` wrapper replace the star-import. Functions without a data argument re-exported as-is.

Note: the DuckDB connection class reports module `_duckdb`, not `duckdb` — the detection covers both.

## Tests

New `TestInputFlavors`: polars/arrow/duckdb inputs for `get_loaded_models` (dict result) and `get_loaded_model_parts` (DataFrame result, flavor round-trip), plus a result-equality check vs pandas. Full suite: 134 passed, 44 skipped, 1 known xfail.