### PR TITLE
refactor: rename tools functions to <action>_<format>_<qualifier> convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ data.types_dict()                                     # → dict
 data.type_tableview("ACLineSegment").df()             # → pandas DataFrame
 data.type_tableview("ACLineSegment").pl()             # → polars DataFrame
 data.filter_triplets(KEY="Type", VALUE=".*Sub.*", regex=True).df()
-data.filter_by_type("Terminal").df()
+data.filter_triplets_by_type("Terminal").df()
 data.references_to("some-uuid").df()
 data.export_to_nquads("/tmp/output.nq")
 
@@ -130,7 +130,7 @@ cim-diff original.xml modified.xml
 |-----------|--------|--------|--------|
 | Parse (cython engine) | 128ms | 156ms | 283ms |
 | type_tableview | 72ms | **21ms** | 53ms |
-| filter_by_type | 103ms | **9ms** | 50ms |
+| filter_triplets_by_type | 103ms | **9ms** | 50ms |
 | types_dict | 21ms | **11ms** | 18ms |
 
 The old `rdf_parser.py` functions still work but emit deprecation warnings.

--- a/docs/migration_0.0_to_0.1.md
+++ b/docs/migration_0.0_to_0.1.md
@@ -76,6 +76,31 @@ They will be removed in 0.2.
 | `triplets.rdf_parser.export_to_networkx` | `triplets.export.export_to_networkx` |
 | All other `rdf_parser.*` query/filter/diff functions | `triplets.tools.*` |
 
+### tools renames
+
+Function names follow `<action>_<format>_<qualifier>` since 0.1 ("triplets" = the
+long ID/KEY/VALUE/INSTANCE_ID table, "tableview" = the pivoted per-class table).
+Old names keep working but emit `DeprecationWarning`; they will be removed in 0.2.
+
+| Old (0.0) | New (0.1) |
+|-----------|-----------|
+| `filter_by_type` | `filter_triplets_by_type` |
+| `filter_by_triplet` | `filter_triplets_by_triplets` |
+| `set_VALUE_at_KEY` | `set_triplets_value_by_key` |
+| `set_VALUE_at_KEY_and_ID` | `set_triplets_value_by_key_and_id` |
+| `update_triplet_from_triplet` | `update_triplets_from_triplets` |
+| `update_triplet_from_tableview` | `update_triplets_from_tableview` |
+| `remove_triplet_from_triplet` | `remove_triplets_from_triplets` |
+| `triplet_to_tableviews` | `triplets_to_tableviews` |
+| `tableview_to_triplet` | `tableview_to_triplets` |
+| `tableviews_to_triplet` | `tableviews_to_triplets` |
+| `diff_between_triplet` | `diff_triplets` |
+| `diff_between_INSTANCE` | `diff_triplets_by_instance` |
+| `print_triplet_diff` | `print_triplets_diff` |
+
+The renames apply to `triplets.tools.*`, the DataFrame methods, and the
+`df.triplets.*` accessor alike.
+
 ### DataFrame methods
 
 The old monkey-patched methods (`data.type_tableview(...)`) still work but the recommended

--- a/docs/source/guides/migration_0.0_to_0.1.md
+++ b/docs/source/guides/migration_0.0_to_0.1.md
@@ -76,6 +76,31 @@ They will be removed in 0.2.
 | `triplets.rdf_parser.export_to_networkx` | `triplets.export.export_to_networkx` |
 | All other `rdf_parser.*` query/filter/diff functions | `triplets.tools.*` |
 
+### tools renames
+
+Function names follow `<action>_<format>_<qualifier>` since 0.1 ("triplets" = the
+long ID/KEY/VALUE/INSTANCE_ID table, "tableview" = the pivoted per-class table).
+Old names keep working but emit `DeprecationWarning`; they will be removed in 0.2.
+
+| Old (0.0.x) | New (0.1) |
+|-----------|-----------|
+| `filter_by_type` | `filter_triplets_by_type` |
+| `filter_by_triplet` | `filter_triplets_by_triplets` |
+| `set_VALUE_at_KEY` | `set_triplets_value_by_key` |
+| `set_VALUE_at_KEY_and_ID` | `set_triplets_value_by_key_and_id` |
+| `update_triplet_from_triplet` | `update_triplets_from_triplets` |
+| `update_triplet_from_tableview` | `update_triplets_from_tableview` |
+| `remove_triplet_from_triplet` | `remove_triplets_from_triplets` |
+| `triplet_to_tableviews` | `triplets_to_tableviews` |
+| `tableview_to_triplet` | `tableview_to_triplets` |
+| `tableviews_to_triplet` | `tableviews_to_triplets` |
+| `diff_between_triplet` | `diff_triplets` |
+| `diff_between_INSTANCE` | `diff_triplets_by_instance` |
+| `print_triplet_diff` | `print_triplets_diff` |
+
+The renames apply to `triplets.tools.*`, the DataFrame methods, and the
+`df.triplets.*` accessor alike.
+
 ### DataFrame methods
 
 The old monkey-patched methods (`data.type_tableview(...)`) still work but the recommended

--- a/tests/test_benchmarks_realgrid.py
+++ b/tests/test_benchmarks_realgrid.py
@@ -102,14 +102,14 @@ def test_type_tableview_duckdb(benchmark):
     assert view is not None and len(view) > 0
 
 
-# ── filter_by_type benchmarks ──────────────────────────────────────────────
+# ── filter_triplets_by_type benchmarks ──────────────────────────────────────────────
 
 @pytest.mark.benchmark(group="filter-by-type")
 def test_filter_by_type_pandas(benchmark):
     import triplets
     df = parse(REALGRID_ZIP, engine=_PARSE_ENGINES[-1], return_type="pandas")
     benchmark.extra_info.update({"engine": "pandas"})
-    result = benchmark(lambda: triplets.tools.filter_by_type(df, TYPE_FOR_VIEW, engine="pandas"))
+    result = benchmark(lambda: triplets.tools.filter_triplets_by_type(df, TYPE_FOR_VIEW, engine="pandas"))
     assert len(result) > 0
 
 
@@ -118,7 +118,7 @@ def test_filter_by_type_polars(benchmark):
     import triplets
     pdf = parse(REALGRID_ZIP, engine=_PARSE_ENGINES[-1], return_type="polars")
     benchmark.extra_info.update({"engine": "polars"})
-    result = benchmark(lambda: triplets.tools.filter_by_type(pdf, TYPE_FOR_VIEW, engine="polars"))
+    result = benchmark(lambda: triplets.tools.filter_triplets_by_type(pdf, TYPE_FOR_VIEW, engine="polars"))
     assert len(result) > 0
 
 
@@ -129,7 +129,7 @@ def test_filter_by_type_duckdb(benchmark):
     data = duckdb.connect()
     data.read_rdf([REALGRID_ZIP])
     benchmark.extra_info.update({"engine": "duckdb"})
-    result = benchmark(lambda: data.filter_by_type(TYPE_FOR_VIEW).df())
+    result = benchmark(lambda: data.filter_triplets_by_type(TYPE_FOR_VIEW).df())
     assert len(result) > 0
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -211,7 +211,7 @@ class TestFilterByTriplet:
 class TestSetValueAtKey:
     def test_modifies_data(self, svedala_eq):
         data = svedala_eq.copy()
-        data.set_VALUE_at_KEY("Model.description", "test_value")
+        data.set_triplets_value_by_key("Model.description", "test_value")
         modified = data[data["KEY"] == "Model.description"]["VALUE"]
         if len(modified) > 0:
             assert all(v == "test_value" for v in modified.values)
@@ -221,7 +221,7 @@ class TestSetValueAtKeyAndID:
     def test_modifies_specific_row(self, svedala_data):
         data = svedala_data.copy()
         target = data[(data["KEY"] == "Type") & (data["VALUE"] == "Substation")].iloc[0]
-        data.set_VALUE_at_KEY_and_ID("Type", "TestType", target["ID"])
+        data.set_triplets_value_by_key_and_id("Type", "TestType", target["ID"])
         modified = data[(data["ID"] == target["ID"]) & (data["KEY"] == "Type")]
         assert modified["VALUE"].iloc[0] == "TestType"
 
@@ -235,7 +235,7 @@ class TestUpdateTripletFromTriplet:
             "VALUE": ["UPDATED_VALUE"],
             "INSTANCE_ID": [data["INSTANCE_ID"].iloc[5]],
         })
-        result = data.update_triplet_from_triplet(update)
+        result = data.update_triplets_from_triplets(update)
         assert isinstance(result, pandas.DataFrame)
 
 
@@ -244,7 +244,7 @@ class TestUpdateTripletFromTableview:
         tv = svedala_data.type_tableview("Substation", string_to_number=False)
         if tv is not None and len(tv) > 0:
             data = svedala_data.copy()
-            result = data.update_triplet_from_tableview(tv)
+            result = data.update_triplets_from_tableview(tv)
             assert isinstance(result, pandas.DataFrame)
 
 
@@ -284,7 +284,7 @@ class TestTableviewsToTriplet:
 class TestTableviewToTriplet:
     def test_returns_dataframe(self, svedala_data):
         tv = svedala_data.type_tableview("ACLineSegment", string_to_number=False)
-        result = tv.tableview_to_triplet()
+        result = tv.tableview_to_triplets()
         assert isinstance(result, pandas.DataFrame)
         assert "ID" in result.columns
         assert "KEY" in result.columns
@@ -292,7 +292,7 @@ class TestTableviewToTriplet:
 
     def test_multivalue(self, svedala_data):
         tv = svedala_data.type_tableview("FullModel", multivalue=True)
-        result = tv.tableview_to_triplet(multivalue=True)
+        result = tv.tableview_to_triplets(multivalue=True)
         assert isinstance(result, pandas.DataFrame)
 
 
@@ -311,7 +311,7 @@ class TestDiffBetweenInstance:
     def test_returns_dataframe(self, svedala_data):
         instances = svedala_data["INSTANCE_ID"].unique()
         if len(instances) >= 2:
-            diff = svedala_data.diff_between_INSTANCE(instances[0], instances[1])
+            diff = svedala_data.diff_triplets_by_instance(instances[0], instances[1])
             assert isinstance(diff, pandas.DataFrame)
 
 
@@ -323,6 +323,29 @@ class TestPrintTripletDiff:
         idx = modified.index[5]
         modified.at[idx, "VALUE"] = str(modified.at[idx, "VALUE"]) + "_CHANGED"
         triplets.rdf_parser.print_triplet_diff(svedala_eq, modified)
+
+
+# ── Deprecated tools aliases (renamed in 0.1) ───────────────────────────────
+
+class TestToolsDeprecatedAliases:
+    def test_module_alias_warns_and_works(self, svedala_data):
+        with pytest.warns(DeprecationWarning, match="filter_triplets_by_type"):
+            result = triplets.tools.filter_by_type(svedala_data, "ACLineSegment")
+        assert len(result) > 0
+
+    def test_dataframe_method_alias_warns(self, svedala_data):
+        with pytest.warns(DeprecationWarning, match="set_triplets_value_by_key"):
+            svedala_data.copy().set_VALUE_at_KEY("Model.description", "x")
+
+    def test_accessor_alias_warns(self, svedala_data):
+        with pytest.warns(DeprecationWarning, match="filter_triplets_by_type"):
+            result = svedala_data.triplets.filter_by_type("ACLineSegment")
+        assert len(result) > 0
+
+    def test_all_aliases_resolve(self):
+        for old_name, new_name in triplets.tools.DEPRECATED_ALIASES.items():
+            assert callable(getattr(triplets.tools, old_name)), old_name
+            assert callable(getattr(triplets.tools, new_name)), new_name
 
 
 # ── Export functions ────────────────────────────────────────────────────────
@@ -524,7 +547,7 @@ class TestCimxmlRoundtrip:
         reimported = pandas.read_RDF([result[0]])
 
         # Diff excluding meta rows (Distribution, NamespaceMap have different IDs per parse)
-        diff = triplets.tools.diff_between_triplet(svedala_eq, reimported)
+        diff = triplets.tools.diff_triplets(svedala_eq, reimported)
         meta_ids = set()
         for meta_type in ("Distribution", "NamespaceMap"):
             ids = diff[
@@ -572,7 +595,7 @@ class TestDuckdbTools:
         assert len(df) > 0
 
     def test_filter_by_type(self, db):
-        df = db.filter_by_type("ACLineSegment").df()
+        df = db.filter_triplets_by_type("ACLineSegment").df()
         assert len(df) > 0
 
     def test_references_to(self, db):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -348,6 +348,24 @@ class TestToolsDeprecatedAliases:
             assert callable(getattr(triplets.tools, new_name)), new_name
 
 
+class TestConvenienceAliases:
+    """First-class aliases (no deprecation) that group functions by prefix for IDE autocomplete."""
+
+    def test_aliases_are_same_function(self):
+        for alias, target in triplets.tools.ALIASES.items():
+            assert getattr(triplets.tools, alias) is getattr(triplets.tools, target), alias
+
+    def test_aliases_work_without_warning(self, svedala_data):
+        import warnings as warnings_module
+        with warnings_module.catch_warnings():
+            warnings_module.simplefilter("error", DeprecationWarning)
+            counts = svedala_data.get_types_count()
+            tv = svedala_data.tableview_by_type("ACLineSegment")
+            accessor_tv = svedala_data.triplets.tableview_by_type("ACLineSegment")
+        assert counts == svedala_data.types_dict()
+        assert len(tv) == len(accessor_tv)
+
+
 # ── Export functions ────────────────────────────────────────────────────────
 
 class TestExportToExcel:

--- a/tools/cim-diff.py
+++ b/tools/cim-diff.py
@@ -1,6 +1,6 @@
 import sys
 import argparse
-from triplets.rdf_parser import print_triplet_diff, load_all_to_dataframe
+from triplets.rdf_parser import print_triplets_diff, load_all_to_dataframe
 
 parser = argparse.ArgumentParser(description="""Create diff in Unified format for XML RDF CIM files. Diff is per object (ID KEY VALUE) not per XML line in file. The input can be xml, zip(xml), zip(zip(xml))""",
                                  epilog="""Copyright (c) Kristjan Vilgo 2021; Licence: GPL 2.0""")
@@ -10,7 +10,7 @@ parser.add_argument('-ex', '--exclude_objects', nargs='+', help='Names of rdf:De
 
 args = parser.parse_args()
 
-print_triplet_diff(load_all_to_dataframe([args.original_file]), load_all_to_dataframe([args.changed_file]), exclude_objects=args.exclude_objects)
+print_triplets_diff(load_all_to_dataframe([args.original_file]), load_all_to_dataframe([args.changed_file]), exclude_objects=args.exclude_objects)
 
 # Example Use
 # python cim-diff.py K:\PROJEKT\ER_EJK_FSYSTEM\TSM_models\eq\20210512T2330Z_ELERING_EQ_001.zip K:\PROJEKT\ER_EJK_FSYSTEM\TSM_models\eq\20210516T2330Z_ELERING_EQ_001.zip

--- a/triplets/_accessor.py
+++ b/triplets/_accessor.py
@@ -103,6 +103,10 @@ def _add_methods(accessor_class, tool_methods):
         setattr(accessor_class, name, _delegate(tools, name))
     for name in EXPORT_METHODS:
         setattr(accessor_class, name, _delegate(export, name))
+    # convenience aliases (first-class, group by prefix for IDE autocomplete)
+    for alias, target in tools.ALIASES.items():
+        if target in tool_methods:
+            setattr(accessor_class, alias, _delegate(tools, alias))
     # old names renamed in 0.1 — delegate through the tools alias, which warns
     for old_name, new_name in tools.DEPRECATED_ALIASES.items():
         if new_name in tool_methods:
@@ -155,6 +159,9 @@ if duckdb:
 
     for name in DUCKDB_TOOL_METHODS:
         setattr(duckdb.DuckDBPyConnection, name, getattr(duckdb_engine, name))
+    for alias, target in tools.ALIASES.items():
+        if target in DUCKDB_TOOL_METHODS:
+            setattr(duckdb.DuckDBPyConnection, alias, getattr(duckdb_engine, target))
     for name in DUCKDB_EXPORT_METHODS:
         setattr(duckdb.DuckDBPyConnection, name, _duckdb_export(name))
     logger.debug("Registered DuckDB connection tools + export helpers")

--- a/triplets/_accessor.py
+++ b/triplets/_accessor.py
@@ -46,14 +46,14 @@ PANDAS_TOOL_METHODS = [
     "references_to_simple", "references_to", "references_from_simple",
     "references_from", "references_all", "references_simple", "references",
     # filter
-    "filter_by_type", "filter_by_triplet", "filter_triplets",
+    "filter_triplets_by_type", "filter_triplets_by_triplets", "filter_triplets",
     # mutate
-    "set_VALUE_at_KEY", "set_VALUE_at_KEY_and_ID",
-    "update_triplet_from_triplet", "update_triplet_from_tableview",
+    "set_triplets_value_by_key", "set_triplets_value_by_key_and_id",
+    "update_triplets_from_triplets", "update_triplets_from_tableview",
     # transform
-    "triplet_to_tableviews", "tableview_to_triplet",
+    "triplets_to_tableviews", "tableview_to_triplets",
     # diff
-    "diff_between_INSTANCE",
+    "diff_triplets_by_instance",
 ]
 
 # Subset of tools currently implemented by the polars engine
@@ -64,11 +64,11 @@ POLARS_TOOL_METHODS = [
     # references
     "references_to", "references_from", "references",
     # filter
-    "filter_by_type", "filter_triplets",
+    "filter_triplets_by_type", "filter_triplets",
     # transform
-    "triplet_to_tableviews", "tableview_to_triplet",
+    "triplets_to_tableviews", "tableview_to_triplets",
     # diff
-    "diff_between_INSTANCE",
+    "diff_triplets_by_instance",
 ]
 
 EXPORT_METHODS = [
@@ -79,7 +79,7 @@ EXPORT_METHODS = [
 # Subset of tools implemented by the duckdb engine (patched onto the
 # connection object directly, the connection holds the triplets table)
 DUCKDB_TOOL_METHODS = [
-    "types_dict", "type_tableview", "filter_triplets", "filter_by_type",
+    "types_dict", "type_tableview", "filter_triplets", "filter_triplets_by_type",
     "references_to", "references_from",
 ]
 
@@ -103,6 +103,10 @@ def _add_methods(accessor_class, tool_methods):
         setattr(accessor_class, name, _delegate(tools, name))
     for name in EXPORT_METHODS:
         setattr(accessor_class, name, _delegate(export, name))
+    # old names renamed in 0.1 — delegate through the tools alias, which warns
+    for old_name, new_name in tools.DEPRECATED_ALIASES.items():
+        if new_name in tool_methods:
+            setattr(accessor_class, old_name, _delegate(tools, old_name))
 
 
 # ── pandas ────────────────────────────────────────────────────────────────────

--- a/triplets/cgmes_tools/pandas_engine.py
+++ b/triplets/cgmes_tools/pandas_engine.py
@@ -299,7 +299,7 @@ def update_FullModel_from_dict(data, metadata, update=True, add=False):
 
     update_data = pandas.DataFrame(additional_meta_list)
 
-    return data.update_triplet_from_triplet(update_data, update, add)
+    return data.update_triplets_from_triplets(update_data, update, add)
 
 def update_FullModel_from_filename(data, parser=get_metadata_from_filename, update=False, add=True):
     """Update FullModel metadata in a triplet dataset using metadata parsed from filenames.
@@ -339,7 +339,7 @@ def update_FullModel_from_filename(data, parser=get_metadata_from_filename, upda
 
     update_data = pandas.DataFrame(additional_meta_list)
 
-    return data.update_triplet_from_triplet(update_data, update, add)
+    return data.update_triplets_from_triplets(update_data, update, add)
 
 
 def update_filename_from_FullModel(data, filename_mask=default_filename_mask, filename_key="label"):
@@ -375,7 +375,7 @@ def update_filename_from_FullModel(data, filename_mask=default_filename_mask, fi
         list_of_updates.append({"ID": label.ID, "KEY": filename_key, "VALUE": filename, "INSTANCE_ID": label.INSTANCE_ID})
 
     update_data = pandas.DataFrame(list_of_updates)
-    return data.update_triplet_from_triplet(update_data, add=False)
+    return data.update_triplets_from_triplets(update_data, add=False)
 
 
 def get_loaded_models(data):
@@ -480,7 +480,7 @@ def get_EIC_to_mRID_map(data, type):
     0  uuid1  10X1001A1001A021
     """
     name_map = {"ID": "mRID", "VALUE": "EIC"}
-    return rdf_parser.filter_by_type(data, type).drop_duplicates().query("KEY == 'IdentifiedObject.energyIdentCodeEic'")[name_map.keys()].rename(columns=name_map)
+    return rdf_parser.filter_triplets_by_type(data, type).drop_duplicates().query("KEY == 'IdentifiedObject.energyIdentCodeEic'")[name_map.keys()].rename(columns=name_map)
 
 
 def get_loaded_model_parts(data):
@@ -904,7 +904,7 @@ def scale_load(data, load_setpoint, cos_f=None):
     load_data["EnergyConsumer.q"] = load_data["EnergyConsumer.p"] * math.tan(math.acos(cos_f))
 
     # Update the dataset with the new scaled P and Q values
-    return data.update_triplet_from_tableview(load_data[['ID', 'EnergyConsumer.p', 'EnergyConsumer.q']], update=True, add=False)
+    return data.update_triplets_from_tableview(load_data[['ID', 'EnergyConsumer.p', 'EnergyConsumer.q']], update=True, add=False)
 
 
 def switch_equipment_terminals(data, equipment_id, connected: str="false"):
@@ -956,7 +956,7 @@ def switch_equipment_terminals(data, equipment_id, connected: str="false"):
     # Set the status (true/false)
     terminals["VALUE"] = connected
 
-    return data.update_triplet_from_triplet(terminals, add=False, update=True)
+    return data.update_triplets_from_triplets(terminals, add=False, update=True)
 
 
 

--- a/triplets/cli/cim_diff.py
+++ b/triplets/cli/cim_diff.py
@@ -47,7 +47,7 @@ After installation, the tool can be invoked in three ways:
     modified = rdf_parser.load_all_to_dataframe(['modified.xml'])
 
     # Print diff
-    rdf_parser.print_triplet_diff(original, modified, exclude_objects=['NamespaceMap', 'Distribution'])
+    rdf_parser.print_triplets_diff(original, modified, exclude_objects=['NamespaceMap', 'Distribution'])
 
 Features
 --------
@@ -105,7 +105,7 @@ Use --no-default-exclusions to include these in the comparison.
 See Also
 --------
 cim-spreadsheet : Tool for converting between CIM XML and spreadsheet formats
-triplets.rdf_parser.print_triplet_diff : Core diff function
+triplets.rdf_parser.print_triplets_diff : Core diff function
 """
 
 import sys
@@ -166,7 +166,7 @@ def main():
     See Also
     --------
     triplets.rdf_parser.load_all_to_dataframe : Loads CIM XML into triplet format
-    triplets.rdf_parser.print_triplet_diff : Prints differences between triplet DataFrames
+    triplets.rdf_parser.print_triplets_diff : Prints differences between triplet DataFrames
     """
     parser = argparse.ArgumentParser(
         description="""Create diff in Unified format for XML RDF CIM files.
@@ -197,7 +197,7 @@ def main():
     original_data = rdf_parser.load_all_to_dataframe([args.original_file])
     changed_data = rdf_parser.load_all_to_dataframe([args.changed_file])
 
-    rdf_parser.print_triplet_diff(original_data, changed_data, exclude_objects=exclude_objects if exclude_objects else None)
+    rdf_parser.print_triplets_diff(original_data, changed_data, exclude_objects=exclude_objects if exclude_objects else None)
 
 if __name__ == "__main__":
     main()

--- a/triplets/cli/cim_spreadsheet.py
+++ b/triplets/cli/cim_spreadsheet.py
@@ -352,7 +352,7 @@ def spreadsheet_to_cim(input_path, output_path, format=None, rdf_map=None,
 
         tableviews.update(csv_dataframes)
 
-    data = rdf_parser.tableviews_to_triplet(tableviews, multivalue=multivalue)
+    data = rdf_parser.tableviews_to_triplets(tableviews, multivalue=multivalue)
 
     if raw_triplets:
         data = pandas.concat([data] + raw_triplets, ignore_index=True)
@@ -361,9 +361,9 @@ def spreadsheet_to_cim(input_path, output_path, format=None, rdf_map=None,
     version = get_versions()['version']
     tool_version = f"triplets-{version}"
     # Old header (md:FullModel) uses Model.applicationSoftware
-    data.set_VALUE_at_KEY("Model.applicationSoftware", tool_version)
+    data.set_triplets_value_by_key("Model.applicationSoftware", tool_version)
     # New header (dcat:Dataset) uses applicationSoftware (eumd namespace)
-    data.set_VALUE_at_KEY("applicationSoftware", tool_version)
+    data.set_triplets_value_by_key("applicationSoftware", tool_version)
 
     if "INSTANCE_ID" not in data.columns or data["INSTANCE_ID"].isna().all():
         data["INSTANCE_ID"] = str(uuid4())

--- a/triplets/export/csv_pandas.py
+++ b/triplets/export/csv_pandas.py
@@ -7,7 +7,7 @@ import logging
 
 from io import BytesIO
 
-from triplets.tools import triplet_to_tableviews
+from triplets.tools import triplets_to_tableviews
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ def export_to_csv(data, path=None, multivalue=True, export_to_memory=False, sing
     if single_file:
         if base_filename is None:
             base_filename = 'export'
-        tableviews = triplet_to_tableviews(data, multivalue=multivalue)
+        tableviews = triplets_to_tableviews(data, multivalue=multivalue)
         exported_files = []
         for class_type, class_data in tableviews.items():
             file_name = '{}_{}.csv'.format(base_filename, class_type)
@@ -47,7 +47,7 @@ def export_to_csv(data, path=None, multivalue=True, export_to_memory=False, sing
         exported_files = []
         for _, label in labels.iterrows():
             instance_data = data[data.INSTANCE_ID == label.INSTANCE_ID]
-            tableviews = triplet_to_tableviews(instance_data, multivalue=multivalue)
+            tableviews = triplets_to_tableviews(instance_data, multivalue=multivalue)
             base_name = label.VALUE.split(".")[0]
             for class_type, class_data in tableviews.items():
                 file_name = '{}_{}.csv'.format(base_name, class_type)

--- a/triplets/export/excel_pandas.py
+++ b/triplets/export/excel_pandas.py
@@ -9,7 +9,7 @@ from io import BytesIO
 
 import pandas
 
-from triplets.tools import triplet_to_tableviews
+from triplets.tools import triplets_to_tableviews
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ def export_to_excel(data, path=None, multivalue=True, export_to_memory=False, si
         if filename is None:
             filename = 'export.xlsx'
 
-        tableviews = triplet_to_tableviews(data, multivalue=multivalue)
+        tableviews = triplets_to_tableviews(data, multivalue=multivalue)
         output = BytesIO()
         output.name = filename
 
@@ -78,7 +78,7 @@ def export_to_excel(data, path=None, multivalue=True, export_to_memory=False, si
 
         for _, label in labels.iterrows():
             instance_data = data[data.INSTANCE_ID == label.INSTANCE_ID]
-            tableviews = triplet_to_tableviews(instance_data, multivalue=multivalue)
+            tableviews = triplets_to_tableviews(instance_data, multivalue=multivalue)
             file_name = '{}.xlsx'.format(label.VALUE.split(".")[0])
             output = BytesIO()
             output.name = file_name

--- a/triplets/rdf_parser.py
+++ b/triplets/rdf_parser.py
@@ -406,93 +406,93 @@ def references(data, ID, levels=1):
 
 
 def filter_by_type(data, type_name, type_key="Type"):
-    """Deprecated: use triplets.tools.filter_by_type()"""
-    warnings.warn("rdf_parser.filter_by_type is deprecated, use triplets.tools.filter_by_type()", DeprecationWarning, stacklevel=2)
-    from .tools import filter_by_type as _fn
+    """Deprecated: use triplets.tools.filter_triplets_by_type()"""
+    warnings.warn("rdf_parser.filter_by_type is deprecated, use triplets.tools.filter_triplets_by_type()", DeprecationWarning, stacklevel=2)
+    from .tools import filter_triplets_by_type as _fn
     return _fn(data, type_name, type_key=type_key)
 
 
 def filter_by_triplet(data, filter_triplet):
-    """Deprecated: use triplets.tools.filter_by_triplet()"""
-    warnings.warn("rdf_parser.filter_by_triplet is deprecated, use triplets.tools.filter_by_triplet()", DeprecationWarning, stacklevel=2)
-    from .tools import filter_by_triplet as _fn
+    """Deprecated: use triplets.tools.filter_triplets_by_triplets()"""
+    warnings.warn("rdf_parser.filter_by_triplet is deprecated, use triplets.tools.filter_triplets_by_triplets()", DeprecationWarning, stacklevel=2)
+    from .tools import filter_triplets_by_triplets as _fn
     return _fn(data, filter_triplet)
 
 
 def set_VALUE_at_KEY(data, key, value):
-    """Deprecated: use triplets.tools.set_VALUE_at_KEY()"""
-    warnings.warn("rdf_parser.set_VALUE_at_KEY is deprecated, use triplets.tools.set_VALUE_at_KEY()", DeprecationWarning, stacklevel=2)
-    from .tools import set_VALUE_at_KEY as _fn
+    """Deprecated: use triplets.tools.set_triplets_value_by_key()"""
+    warnings.warn("rdf_parser.set_VALUE_at_KEY is deprecated, use triplets.tools.set_triplets_value_by_key()", DeprecationWarning, stacklevel=2)
+    from .tools import set_triplets_value_by_key as _fn
     return _fn(data, key, value)
 
 
 def set_VALUE_at_KEY_and_ID(data, key, value, id):
-    """Deprecated: use triplets.tools.set_VALUE_at_KEY_and_ID()"""
-    warnings.warn("rdf_parser.set_VALUE_at_KEY_and_ID is deprecated, use triplets.tools.set_VALUE_at_KEY_and_ID()", DeprecationWarning, stacklevel=2)
-    from .tools import set_VALUE_at_KEY_and_ID as _fn
+    """Deprecated: use triplets.tools.set_triplets_value_by_key_and_id()"""
+    warnings.warn("rdf_parser.set_VALUE_at_KEY_and_ID is deprecated, use triplets.tools.set_triplets_value_by_key_and_id()", DeprecationWarning, stacklevel=2)
+    from .tools import set_triplets_value_by_key_and_id as _fn
     return _fn(data, key, value, id)
 
 
 def triplet_to_tableviews(triplet_df, multivalue=False):
-    """Deprecated: use triplets.tools.triplet_to_tableviews()"""
-    warnings.warn("rdf_parser.triplet_to_tableviews is deprecated, use triplets.tools.triplet_to_tableviews()", DeprecationWarning, stacklevel=2)
-    from .tools import triplet_to_tableviews as _fn
+    """Deprecated: use triplets.tools.triplets_to_tableviews()"""
+    warnings.warn("rdf_parser.triplet_to_tableviews is deprecated, use triplets.tools.triplets_to_tableviews()", DeprecationWarning, stacklevel=2)
+    from .tools import triplets_to_tableviews as _fn
     return _fn(triplet_df, multivalue=multivalue)
 
 
 def tableviews_to_triplet(tableviews, multivalue=False):
-    """Deprecated: use triplets.tools.tableviews_to_triplet()"""
-    warnings.warn("rdf_parser.tableviews_to_triplet is deprecated, use triplets.tools.tableviews_to_triplet()", DeprecationWarning, stacklevel=2)
-    from .tools import tableviews_to_triplet as _fn
+    """Deprecated: use triplets.tools.tableviews_to_triplets()"""
+    warnings.warn("rdf_parser.tableviews_to_triplet is deprecated, use triplets.tools.tableviews_to_triplets()", DeprecationWarning, stacklevel=2)
+    from .tools import tableviews_to_triplets as _fn
     return _fn(tableviews, multivalue=multivalue)
 
 
 def tableview_to_triplet(data, multivalue=False):
-    """Deprecated: use triplets.tools.tableview_to_triplet()"""
-    warnings.warn("rdf_parser.tableview_to_triplet is deprecated, use triplets.tools.tableview_to_triplet()", DeprecationWarning, stacklevel=2)
-    from .tools import tableview_to_triplet as _fn
+    """Deprecated: use triplets.tools.tableview_to_triplets()"""
+    warnings.warn("rdf_parser.tableview_to_triplet is deprecated, use triplets.tools.tableview_to_triplets()", DeprecationWarning, stacklevel=2)
+    from .tools import tableview_to_triplets as _fn
     return _fn(data, multivalue=multivalue)
 
 
 def update_triplet_from_triplet(data, update_data, update=True, add=True):
-    """Deprecated: use triplets.tools.update_triplet_from_triplet()"""
-    warnings.warn("rdf_parser.update_triplet_from_triplet is deprecated, use triplets.tools.update_triplet_from_triplet()", DeprecationWarning, stacklevel=2)
-    from .tools import update_triplet_from_triplet as _fn
+    """Deprecated: use triplets.tools.update_triplets_from_triplets()"""
+    warnings.warn("rdf_parser.update_triplet_from_triplet is deprecated, use triplets.tools.update_triplets_from_triplets()", DeprecationWarning, stacklevel=2)
+    from .tools import update_triplets_from_triplets as _fn
     return _fn(data, update_data, update=update, add=add)
 
 
 def update_triplet_from_tableview(data, tableview, update=True, add=True, instance_id=None):
-    """Deprecated: use triplets.tools.update_triplet_from_tableview()"""
-    warnings.warn("rdf_parser.update_triplet_from_tableview is deprecated, use triplets.tools.update_triplet_from_tableview()", DeprecationWarning, stacklevel=2)
-    from .tools import update_triplet_from_tableview as _fn
+    """Deprecated: use triplets.tools.update_triplets_from_tableview()"""
+    warnings.warn("rdf_parser.update_triplet_from_tableview is deprecated, use triplets.tools.update_triplets_from_tableview()", DeprecationWarning, stacklevel=2)
+    from .tools import update_triplets_from_tableview as _fn
     return _fn(data, tableview, update=update, add=add, instance_id=instance_id)
 
 
 def remove_triplet_from_triplet(from_triplet, what_triplet, columns=["ID", "KEY", "VALUE"]):
-    """Deprecated: use triplets.tools.remove_triplet_from_triplet()"""
-    warnings.warn("rdf_parser.remove_triplet_from_triplet is deprecated, use triplets.tools.remove_triplet_from_triplet()", DeprecationWarning, stacklevel=2)
-    from .tools import remove_triplet_from_triplet as _fn
+    """Deprecated: use triplets.tools.remove_triplets_from_triplets()"""
+    warnings.warn("rdf_parser.remove_triplet_from_triplet is deprecated, use triplets.tools.remove_triplets_from_triplets()", DeprecationWarning, stacklevel=2)
+    from .tools import remove_triplets_from_triplets as _fn
     return _fn(from_triplet, what_triplet, columns=columns)
 
 
 def diff_between_triplet(old_data, new_data):
-    """Deprecated: use triplets.tools.diff_between_triplet()"""
-    warnings.warn("rdf_parser.diff_between_triplet is deprecated, use triplets.tools.diff_between_triplet()", DeprecationWarning, stacklevel=2)
-    from .tools import diff_between_triplet as _fn
+    """Deprecated: use triplets.tools.diff_triplets()"""
+    warnings.warn("rdf_parser.diff_between_triplet is deprecated, use triplets.tools.diff_triplets()", DeprecationWarning, stacklevel=2)
+    from .tools import diff_triplets as _fn
     return _fn(old_data, new_data)
 
 
 def diff_between_INSTANCE(data, INSTANCE_ID_1, INSTANCE_ID_2):
-    """Deprecated: use triplets.tools.diff_between_INSTANCE()"""
-    warnings.warn("rdf_parser.diff_between_INSTANCE is deprecated, use triplets.tools.diff_between_INSTANCE()", DeprecationWarning, stacklevel=2)
-    from .tools import diff_between_INSTANCE as _fn
+    """Deprecated: use triplets.tools.diff_triplets_by_instance()"""
+    warnings.warn("rdf_parser.diff_between_INSTANCE is deprecated, use triplets.tools.diff_triplets_by_instance()", DeprecationWarning, stacklevel=2)
+    from .tools import diff_triplets_by_instance as _fn
     return _fn(data, INSTANCE_ID_1, INSTANCE_ID_2)
 
 
 def print_triplet_diff(old_data, new_data, file_id_object="Distribution", file_id_key="label", exclude_objects=None):
-    """Deprecated: use triplets.tools.print_triplet_diff()"""
-    warnings.warn("rdf_parser.print_triplet_diff is deprecated, use triplets.tools.print_triplet_diff()", DeprecationWarning, stacklevel=2)
-    from .tools import print_triplet_diff as _fn
+    """Deprecated: use triplets.tools.print_triplets_diff()"""
+    warnings.warn("rdf_parser.print_triplet_diff is deprecated, use triplets.tools.print_triplets_diff()", DeprecationWarning, stacklevel=2)
+    from .tools import print_triplets_diff as _fn
     return _fn(old_data, new_data, file_id_object=file_id_object, file_id_key=file_id_key, exclude_objects=exclude_objects)
 
 

--- a/triplets/tools/__init__.py
+++ b/triplets/tools/__init__.py
@@ -12,6 +12,8 @@ specified explicitly with engine="pandas" or engine="polars".
 """
 
 import logging
+import functools
+import warnings
 
 logger = logging.getLogger(__name__)
 
@@ -84,75 +86,112 @@ def references_simple(data, reference, columns=None, levels=1, engine="auto"):
 def references(data, ID, levels=1, engine="auto"):
     return _get_engine(engine, data).references(data, ID, levels=levels)
 
-def filter_by_type(data, type_name, type_key="Type", engine="auto"):
-    return _get_engine(engine, data).filter_by_type(data, type_name, type_key=type_key)
+def filter_triplets_by_type(data, type_name, type_key="Type", engine="auto"):
+    return _get_engine(engine, data).filter_triplets_by_type(data, type_name, type_key=type_key)
 
-def filter_by_triplet(data, filter_triplet, engine="auto"):
-    return _get_engine(engine, data).filter_by_triplet(data, filter_triplet)
+def filter_triplets_by_triplets(data, filter_triplet, engine="auto"):
+    return _get_engine(engine, data).filter_triplets_by_triplets(data, filter_triplet)
 
 def filter_triplets(data, ID=None, KEY=None, VALUE=None, INSTANCE_ID=None, regex=False, engine="auto"):
     return _get_engine(engine, data).filter_triplets(data, ID=ID, KEY=KEY, VALUE=VALUE, INSTANCE_ID=INSTANCE_ID, regex=regex)
 
-def set_VALUE_at_KEY(data, key, value, engine="auto"):
-    return _get_engine(engine, data).set_VALUE_at_KEY(data, key, value)
+def set_triplets_value_by_key(data, key, value, engine="auto"):
+    return _get_engine(engine, data).set_triplets_value_by_key(data, key, value)
 
-def set_VALUE_at_KEY_and_ID(data, key, value, id, engine="auto"):
-    return _get_engine(engine, data).set_VALUE_at_KEY_and_ID(data, key, value, id)
+def set_triplets_value_by_key_and_id(data, key, value, id, engine="auto"):
+    return _get_engine(engine, data).set_triplets_value_by_key_and_id(data, key, value, id)
 
-def triplet_to_tableviews(triplet_df, multivalue=False, engine="auto"):
-    return _get_engine(engine, triplet_df).triplet_to_tableviews(triplet_df, multivalue=multivalue)
+def triplets_to_tableviews(triplet_df, multivalue=False, engine="auto"):
+    return _get_engine(engine, triplet_df).triplets_to_tableviews(triplet_df, multivalue=multivalue)
 
-def tableviews_to_triplet(tableviews, multivalue=False, engine="auto"):
+def tableviews_to_triplets(tableviews, multivalue=False, engine="auto"):
     # tableviews is a dict — detect engine from first value if available
     data = next(iter(tableviews.values()), None) if tableviews else None
-    return _get_engine(engine, data).tableviews_to_triplet(tableviews, multivalue=multivalue)
+    return _get_engine(engine, data).tableviews_to_triplets(tableviews, multivalue=multivalue)
 
-def tableview_to_triplet(data, multivalue=False, engine="auto"):
-    return _get_engine(engine, data).tableview_to_triplet(data, multivalue=multivalue)
+def tableview_to_triplets(data, multivalue=False, engine="auto"):
+    return _get_engine(engine, data).tableview_to_triplets(data, multivalue=multivalue)
 
 def get_object_data(data, object_UUID, engine="auto"):
     return _get_engine(engine, data).get_object_data(data, object_UUID)
 
-def update_triplet_from_triplet(data, update_data, update=True, add=True, engine="auto"):
-    return _get_engine(engine, data).update_triplet_from_triplet(data, update_data, update=update, add=add)
+def update_triplets_from_triplets(data, update_data, update=True, add=True, engine="auto"):
+    return _get_engine(engine, data).update_triplets_from_triplets(data, update_data, update=update, add=add)
 
-def update_triplet_from_tableview(data, tableview, update=True, add=True, instance_id=None, engine="auto"):
-    return _get_engine(engine, data).update_triplet_from_tableview(data, tableview, update=update, add=add, instance_id=instance_id)
+def update_triplets_from_tableview(data, tableview, update=True, add=True, instance_id=None, engine="auto"):
+    return _get_engine(engine, data).update_triplets_from_tableview(data, tableview, update=update, add=add, instance_id=instance_id)
 
-def remove_triplet_from_triplet(from_triplet, what_triplet, columns=["ID", "KEY", "VALUE"], engine="auto"):
-    return _get_engine(engine, from_triplet).remove_triplet_from_triplet(from_triplet, what_triplet, columns=columns)
+def remove_triplets_from_triplets(from_triplet, what_triplet, columns=["ID", "KEY", "VALUE"], engine="auto"):
+    return _get_engine(engine, from_triplet).remove_triplets_from_triplets(from_triplet, what_triplet, columns=columns)
 
-def diff_between_triplet(old_data, new_data, engine="auto"):
-    return _get_engine(engine, old_data).diff_between_triplet(old_data, new_data)
+def diff_triplets(old_data, new_data, engine="auto"):
+    return _get_engine(engine, old_data).diff_triplets(old_data, new_data)
 
-def diff_between_INSTANCE(data, INSTANCE_ID_1, INSTANCE_ID_2, engine="auto"):
-    return _get_engine(engine, data).diff_between_INSTANCE(data, INSTANCE_ID_1, INSTANCE_ID_2)
+def diff_triplets_by_instance(data, INSTANCE_ID_1, INSTANCE_ID_2, engine="auto"):
+    return _get_engine(engine, data).diff_triplets_by_instance(data, INSTANCE_ID_1, INSTANCE_ID_2)
 
-def print_triplet_diff(old_data, new_data, file_id_object="Distribution", file_id_key="label", exclude_objects=None, engine="auto"):
-    return _get_engine(engine, old_data).print_triplet_diff(old_data, new_data, file_id_object=file_id_object, file_id_key=file_id_key, exclude_objects=exclude_objects)
+def print_triplets_diff(old_data, new_data, file_id_object="Distribution", file_id_key="label", exclude_objects=None, engine="auto"):
+    return _get_engine(engine, old_data).print_triplets_diff(old_data, new_data, file_id_object=file_id_object, file_id_key=file_id_key, exclude_objects=exclude_objects)
+
+
+# ── Deprecated names (renamed in 0.1; removal in 0.2) ───────────────────────
+# Old name → new name; old names keep working but emit DeprecationWarning.
+DEPRECATED_ALIASES = {
+    "filter_by_type": "filter_triplets_by_type",
+    "filter_by_triplet": "filter_triplets_by_triplets",
+    "set_VALUE_at_KEY": "set_triplets_value_by_key",
+    "set_VALUE_at_KEY_and_ID": "set_triplets_value_by_key_and_id",
+    "update_triplet_from_triplet": "update_triplets_from_triplets",
+    "update_triplet_from_tableview": "update_triplets_from_tableview",
+    "remove_triplet_from_triplet": "remove_triplets_from_triplets",
+    "triplet_to_tableviews": "triplets_to_tableviews",
+    "tableview_to_triplet": "tableview_to_triplets",
+    "tableviews_to_triplet": "tableviews_to_triplets",
+    "diff_between_triplet": "diff_triplets",
+    "diff_between_INSTANCE": "diff_triplets_by_instance",
+    "print_triplet_diff": "print_triplets_diff",
+}
+
+
+def _deprecated_alias(old_name, new_name):
+    new_function = globals()[new_name]
+
+    @functools.wraps(new_function)
+    def wrapper(*args, **kwargs):
+        warnings.warn(f"tools.{old_name} is deprecated, use tools.{new_name}()",
+                      DeprecationWarning, stacklevel=2)
+        return new_function(*args, **kwargs)
+
+    return wrapper
+
+
+for _old, _new in DEPRECATED_ALIASES.items():
+    globals()[_old] = _deprecated_alias(_old, _new)
 
 
 # ── Register on pandas DataFrames (backwards compat) ────────────────────────
+# New names delegate directly; deprecated old names go through the warning alias.
+DATAFRAME_METHODS = [
+    "type_tableview", "key_tableview", "id_tableview", "types_dict",
+    "get_object_data",
+    "references_to_simple", "references_to", "references_from_simple",
+    "references_from", "references_all", "references_simple", "references",
+    "filter_triplets_by_type", "filter_triplets_by_triplets", "filter_triplets",
+    "set_triplets_value_by_key", "set_triplets_value_by_key_and_id",
+    "tableview_to_triplets", "update_triplets_from_triplets",
+    "update_triplets_from_tableview", "diff_triplets_by_instance",
+]
+
 import pandas
-pandas.DataFrame.type_tableview = lambda self, *a, **kw: type_tableview(self, *a, **kw)
-pandas.DataFrame.key_tableview = lambda self, *a, **kw: key_tableview(self, *a, **kw)
-pandas.DataFrame.id_tableview = lambda self, *a, **kw: id_tableview(self, *a, **kw)
-pandas.DataFrame.types_dict = lambda self, **kw: types_dict(self, **kw)
-pandas.DataFrame.get_object_data = lambda self, *a, **kw: get_object_data(self, *a, **kw)
-pandas.DataFrame.references_to_simple = lambda self, *a, **kw: references_to_simple(self, *a, **kw)
-pandas.DataFrame.references_to = lambda self, *a, **kw: references_to(self, *a, **kw)
-pandas.DataFrame.references_from_simple = lambda self, *a, **kw: references_from_simple(self, *a, **kw)
-pandas.DataFrame.references_from = lambda self, *a, **kw: references_from(self, *a, **kw)
-pandas.DataFrame.references_all = lambda self, **kw: references_all(self, **kw)
-pandas.DataFrame.references_simple = lambda self, *a, **kw: references_simple(self, *a, **kw)
-pandas.DataFrame.references = lambda self, *a, **kw: references(self, *a, **kw)
-pandas.DataFrame.filter_by_type = lambda self, *a, **kw: filter_by_type(self, *a, **kw)
-pandas.DataFrame.filter_by_triplet = lambda self, *a, **kw: filter_by_triplet(self, *a, **kw)
-pandas.DataFrame.filter_triplets = lambda self, *a, **kw: filter_triplets(self, *a, **kw)
-pandas.DataFrame.set_VALUE_at_KEY = lambda self, *a, **kw: set_VALUE_at_KEY(self, *a, **kw)
-pandas.DataFrame.set_VALUE_at_KEY_and_ID = lambda self, *a, **kw: set_VALUE_at_KEY_and_ID(self, *a, **kw)
-pandas.DataFrame.tableview_to_triplet = lambda self, *a, **kw: tableview_to_triplet(self, *a, **kw)
-pandas.DataFrame.update_triplet_from_triplet = lambda self, *a, **kw: update_triplet_from_triplet(self, *a, **kw)
-pandas.DataFrame.update_triplet_from_tableview = lambda self, *a, **kw: update_triplet_from_tableview(self, *a, **kw)
-pandas.DataFrame.diff_between_INSTANCE = lambda self, *a, **kw: diff_between_INSTANCE(self, *a, **kw)
+
+
+def _dataframe_method(function):
+    def method(self, *args, **kwargs):
+        return function(self, *args, **kwargs)
+    return method
+
+
+for _name in DATAFRAME_METHODS + list(DEPRECATED_ALIASES):
+    setattr(pandas.DataFrame, _name, _dataframe_method(globals()[_name]))
+
 pandas.DataFrame.changes = pandas.DataFrame()

--- a/triplets/tools/__init__.py
+++ b/triplets/tools/__init__.py
@@ -134,6 +134,20 @@ def print_triplets_diff(old_data, new_data, file_id_object="Distribution", file_
     return _get_engine(engine, old_data).print_triplets_diff(old_data, new_data, file_id_object=file_id_object, file_id_key=file_id_key, exclude_objects=exclude_objects)
 
 
+# ── Convenience aliases (not deprecated — both names are first-class) ───────
+# Alias → target. The aliases group functions by prefix for IDE autocomplete:
+# typing "get", "tableview" or "references" surfaces the whole family.
+ALIASES = {
+    "get_types_count": "types_dict",
+    "tableview_by_type": "type_tableview",
+    "tableview_by_key": "key_tableview",
+    "tableview_by_id": "id_tableview",
+}
+
+for _alias, _target in ALIASES.items():
+    globals()[_alias] = globals()[_target]
+
+
 # ── Deprecated names (renamed in 0.1; removal in 0.2) ───────────────────────
 # Old name → new name; old names keep working but emit DeprecationWarning.
 DEPRECATED_ALIASES = {
@@ -191,7 +205,7 @@ def _dataframe_method(function):
     return method
 
 
-for _name in DATAFRAME_METHODS + list(DEPRECATED_ALIASES):
+for _name in DATAFRAME_METHODS + list(ALIASES) + list(DEPRECATED_ALIASES):
     setattr(pandas.DataFrame, _name, _dataframe_method(globals()[_name]))
 
 pandas.DataFrame.changes = pandas.DataFrame()

--- a/triplets/tools/duckdb_engine.py
+++ b/triplets/tools/duckdb_engine.py
@@ -49,7 +49,7 @@ def filter_triplets(self, ID=None, KEY=None, VALUE=None, INSTANCE_ID=None,
     return self.sql(f"SELECT * FROM {table_name} WHERE {where}")
 
 
-def filter_by_type(self, type_name, table_name=TABLE_NAME):
+def filter_triplets_by_type(self, type_name, table_name=TABLE_NAME):
     """Filter to only objects of a specific type. Returns DuckDBPyRelation (lazy)."""
     return self.sql(f"""
         SELECT d.* FROM {table_name} d

--- a/triplets/tools/pandas_engine.py
+++ b/triplets/tools/pandas_engine.py
@@ -208,7 +208,7 @@ def id_tableview(data, id, string_to_number=True):
     if isinstance(id, list):
         id = pandas.DataFrame({"ID": id})
 
-    id_data = filter_by_triplet(data, id)
+    id_data = filter_triplets_by_triplets(data, id)
 
     if id_data.empty:
         logger.warning(f'No data available for {id}')
@@ -532,7 +532,7 @@ def types_dict(data):
     return types_dictionary
 
 
-def set_VALUE_at_KEY(data, key, value):
+def set_triplets_value_by_key(data, key, value):
     """Set the value for all instances of a specified key.
 
     Parameters
@@ -551,12 +551,12 @@ def set_VALUE_at_KEY(data, key, value):
 
     Examples
     --------
-    >>> data.set_VALUE_at_KEY("label", "new_label")
+    >>> data.set_triplets_value_by_key("label", "new_label")
     """
     data.loc[data[data.KEY == key].index, "VALUE"] = value  # TODO add changes to change DataFrame
 
 
-def set_VALUE_at_KEY_and_ID(data, key, value, id):
+def set_triplets_value_by_key_and_id(data, key, value, id):
     """Set the value for a specific key and ID.
 
     Parameters
@@ -572,12 +572,12 @@ def set_VALUE_at_KEY_and_ID(data, key, value, id):
 
     Examples
     --------
-    >>> data.set_VALUE_at_KEY_and_ID("label", "new_label", "uuid1")
+    >>> data.set_triplets_value_by_key_and_id("label", "new_label", "uuid1")
     """
     data.loc[data[(data.ID == id) & (data.KEY == key)].index, "VALUE"] = value
 
 
-def triplet_to_tableviews(triplet_df, multivalue=False):
+def triplets_to_tableviews(triplet_df, multivalue=False):
     """Convert triplet DataFrame to dict of tableview DataFrames.
 
     Parameters
@@ -601,7 +601,7 @@ def triplet_to_tableviews(triplet_df, multivalue=False):
     return tableviews
 
 
-def tableviews_to_triplet(tableviews, multivalue=False):
+def tableviews_to_triplets(tableviews, multivalue=False):
     """Convert dict of tableview DataFrames to triplet DataFrame.
 
     Parameters
@@ -620,7 +620,7 @@ def tableviews_to_triplet(tableviews, multivalue=False):
     for class_name, df in tableviews.items():
         if 'Type' not in df.columns:
             df = df.assign(Type=class_name)
-        triplet = tableview_to_triplet(df, multivalue=multivalue)
+        triplet = tableview_to_triplets(df, multivalue=multivalue)
         triplet = triplet[triplet['VALUE'].notna()]
         all_triplets.append(triplet)
     if not all_triplets:
@@ -650,7 +650,7 @@ def get_object_data(data, object_UUID):
     return data.query("ID == '{}'".format(object_UUID)).set_index("KEY")["VALUE"]
 
 
-def tableview_to_triplet(data, multivalue=False):
+def tableview_to_triplets(data, multivalue=False):
     """Convert a table view back to a triplet format.
 
     Parameters
@@ -685,7 +685,7 @@ def tableview_to_triplet(data, multivalue=False):
     return triplet_df.astype(str)
 
 
-def update_triplet_from_triplet(data, update_data, update=True, add=True):
+def update_triplets_from_triplets(data, update_data, update=True, add=True):
     """Update or add triplets from another triplet dataset.
 
     Parameters
@@ -711,7 +711,7 @@ def update_triplet_from_triplet(data, update_data, update=True, add=True):
 
     Examples
     --------
-    >>> updated_data = data.update_triplet_from_triplet(update_data)
+    >>> updated_data = data.update_triplets_from_triplets(update_data)
     """
     write_columns = ["ID", "KEY", "VALUE", "INSTANCE_ID"]
 
@@ -739,7 +739,7 @@ def update_triplet_from_triplet(data, update_data, update=True, add=True):
     return data
 
 
-def update_triplet_from_tableview(data, tableview, update=True, add=True, instance_id=None):
+def update_triplets_from_tableview(data, tableview, update=True, add=True, instance_id=None):
     """Update or add triplets from a table view.
 
     Parameters
@@ -762,17 +762,17 @@ def update_triplet_from_tableview(data, tableview, update=True, add=True, instan
 
     Examples
     --------
-    >>> updated_data = data.update_triplet_from_tableview(table_view, instance_id="uuid1")
+    >>> updated_data = data.update_triplets_from_tableview(table_view, instance_id="uuid1")
     """
-    update_triplet = tableview_to_triplet(tableview)
+    update_triplet = tableview_to_triplets(tableview)
 
     if instance_id:
         update_triplet["INSTANCE_ID"] = instance_id
 
-    return update_triplet_from_triplet(data, update_triplet, update, add)
+    return update_triplets_from_triplets(data, update_triplet, update, add)
 
 
-def remove_triplet_from_triplet(from_triplet, what_triplet, columns=["ID", "KEY", "VALUE"]):
+def remove_triplets_from_triplets(from_triplet, what_triplet, columns=["ID", "KEY", "VALUE"]):
     """Remove triplets from one dataset that match another.
 
     Parameters
@@ -791,12 +791,12 @@ def remove_triplet_from_triplet(from_triplet, what_triplet, columns=["ID", "KEY"
 
     Examples
     --------
-    >>> result = remove_triplet_from_triplet(data, to_remove)
+    >>> result = remove_triplets_from_triplets(data, to_remove)
     """
     return from_triplet.drop(from_triplet.reset_index().merge(what_triplet[columns], on=columns, how="inner")["index"], axis=0)
 
 
-def filter_by_triplet(data, filter_triplet):
+def filter_triplets_by_triplets(data, filter_triplet):
     """Filter riplet DataFrame using IDs from another DataFrame.
 
     Parameters
@@ -813,13 +813,13 @@ def filter_by_triplet(data, filter_triplet):
 
     Examples
     --------
-    >>> filtered = filter_by_triplet(data, filter_triplet)
+    >>> filtered = filter_triplets_by_triplets(data, filter_triplet)
     """
 
     return data.merge(filter_triplet[["ID"]], on="ID", how="inner")
 
 
-def filter_by_type(data, type_name, type_key="Type"):
+def filter_triplets_by_type(data, type_name, type_key="Type"):
     """Filter triplet dataset by objects of a specific type.
 
     Parameters
@@ -838,11 +838,11 @@ def filter_by_type(data, type_name, type_key="Type"):
 
     Examples
     --------
-    >>> filtered = filter_by_type(data, "ACLineSegment")
+    >>> filtered = filter_triplets_by_type(data, "ACLineSegment")
     """
     filter_triplet = data[(data.KEY == type_key) & (data.VALUE == type_name)]
 
-    return filter_by_triplet(data, filter_triplet)
+    return filter_triplets_by_triplets(data, filter_triplet)
 
 
 def filter_triplets(data, ID=None, KEY=None, VALUE=None, INSTANCE_ID=None, regex=False):
@@ -877,7 +877,7 @@ def filter_triplets(data, ID=None, KEY=None, VALUE=None, INSTANCE_ID=None, regex
     return data[mask]
 
 
-def diff_between_triplet(old_data, new_data):
+def diff_triplets(old_data, new_data):
     """Compute the difference between two Triplet DataFrames.
 
     Parameters
@@ -895,11 +895,11 @@ def diff_between_triplet(old_data, new_data):
 
     Examples
     --------
-    >>> diff = diff_between_triplet(old_data, new_data)
+    >>> diff = diff_triplets(old_data, new_data)
     """
     return old_data.merge(new_data, on=["ID", "KEY", "VALUE"], how='outer', indicator=True, suffixes=("_OLD", "_NEW"), sort=False).query("_merge != 'both'")
 
-def diff_between_INSTANCE(data, INSTANCE_ID_1, INSTANCE_ID_2):
+def diff_triplets_by_instance(data, INSTANCE_ID_1, INSTANCE_ID_2):
     """Identify differences between two loaded INSTANCES, by thier INSTACE_ID in the same Triplet DataFrame.
 
     Parameters
@@ -918,13 +918,13 @@ def diff_between_INSTANCE(data, INSTANCE_ID_1, INSTANCE_ID_2):
 
     Examples
     --------
-    >>> diff = diff_between_INSTANCE('uuid1', 'uuid2')
+    >>> diff = diff_triplets_by_instance('uuid1', 'uuid2')
     """
     diff = data.query("INSTANCE_ID == '{}' or INSTANCE_ID == '{}'".format(INSTANCE_ID_1, INSTANCE_ID_2)).drop_duplicates(["ID", "KEY", "VALUE"], keep=False)
 
     return diff
 
-def print_triplet_diff(old_data, new_data, file_id_object="Distribution", file_id_key="label", exclude_objects=None):
+def print_triplets_diff(old_data, new_data, file_id_object="Distribution", file_id_key="label", exclude_objects=None):
     """Print a human-readable diff of two triplet datasets.
 
     Parameters
@@ -948,24 +948,24 @@ def print_triplet_diff(old_data, new_data, file_id_object="Distribution", file_i
 
     Examples
     --------
-    >>> print_triplet_diff(old_data, new_data, exclude_objects=["NamespaceMap"])
+    >>> print_triplets_diff(old_data, new_data, exclude_objects=["NamespaceMap"])
     """
     # Get diff between datasets
-    diff = diff_between_triplet(old_data, new_data)
+    diff = diff_triplets(old_data, new_data)
     # Convert _merge to plain string before replacing (avoids categorical setitem error with pyarrow dtypes)
     diff["_merge"] = diff["_merge"].astype(str).replace({"left_only": "-", "right_only": "+"})
     diff = diff.sort_values(by=['ID', 'KEY'])
 
     # Extract internal structures keeping file name information
-    file_id_data = filter_by_type(diff, file_id_object)
-    diff = remove_triplet_from_triplet(diff, file_id_data)
+    file_id_data = filter_triplets_by_type(diff, file_id_object)
+    diff = remove_triplets_from_triplets(diff, file_id_data)
     logger.info(f"INFO - removed {file_id_object} from diff")
 
     # Exclude defined types form export
     if exclude_objects:
         for object_name in exclude_objects:
-            excluded_data = filter_by_type(diff, object_name)
-            diff = remove_triplet_from_triplet(diff, excluded_data)
+            excluded_data = filter_triplets_by_type(diff, object_name)
+            diff = remove_triplets_from_triplets(diff, excluded_data)
             logger.info(f"INFO - removed {object_name} from diff")
 
     # Extract types on left and right to get changed/modified types

--- a/triplets/tools/polars_engine.py
+++ b/triplets/tools/polars_engine.py
@@ -238,7 +238,7 @@ def references(data, ID, levels=1):
     return references_simple(data, ID, levels=levels)
 
 
-def filter_by_type(data, type_name, type_key="Type"):
+def filter_triplets_by_type(data, type_name, type_key="Type"):
     """Filter triplet data to only include objects of a specific type."""
     type_ids = data.filter(
         (pl.col("KEY") == type_key) & (pl.col("VALUE") == type_name)
@@ -246,7 +246,7 @@ def filter_by_type(data, type_name, type_key="Type"):
     return type_ids.join(data, on="ID", how="inner")
 
 
-def filter_by_triplet(data, filter_triplet):
+def filter_triplets_by_triplets(data, filter_triplet):
     """Filter data to rows matching the filter triplet."""
     return data.join(filter_triplet.select(["ID", "KEY", "VALUE"]), on=["ID", "KEY", "VALUE"], how="semi")
 
@@ -278,7 +278,7 @@ def filter_triplets(data, ID=None, KEY=None, VALUE=None, INSTANCE_ID=None, regex
     return data.filter(expr)
 
 
-def set_VALUE_at_KEY(data, key, value):
+def set_triplets_value_by_key(data, key, value):
     """Set VALUE for all rows with a given KEY (in-place mutation via reassignment)."""
     return data.with_columns(
         pl.when(pl.col("KEY") == key)
@@ -288,7 +288,7 @@ def set_VALUE_at_KEY(data, key, value):
     )
 
 
-def set_VALUE_at_KEY_and_ID(data, key, value, id):
+def set_triplets_value_by_key_and_id(data, key, value, id):
     """Set VALUE for a specific KEY and ID combination."""
     return data.with_columns(
         pl.when((pl.col("KEY") == key) & (pl.col("ID") == id))
@@ -298,7 +298,7 @@ def set_VALUE_at_KEY_and_ID(data, key, value, id):
     )
 
 
-def triplet_to_tableviews(triplet_df, multivalue=False):
+def triplets_to_tableviews(triplet_df, multivalue=False):
     """Convert triplet DataFrame to dict of tableview DataFrames."""
     td = types_dict(triplet_df)
     tableviews = {}
@@ -309,13 +309,13 @@ def triplet_to_tableviews(triplet_df, multivalue=False):
     return tableviews
 
 
-def tableviews_to_triplet(tableviews, multivalue=False):
+def tableviews_to_triplets(tableviews, multivalue=False):
     """Convert dict of tableview DataFrames to triplet DataFrame."""
     all_triplets = []
     for class_name, df in tableviews.items():
         if "Type" not in df.columns:
             df = df.with_columns(pl.lit(class_name).alias("Type"))
-        triplet = tableview_to_triplet(df, multivalue=multivalue)
+        triplet = tableview_to_triplets(df, multivalue=multivalue)
         triplet = triplet.filter(pl.col("VALUE").is_not_null())
         all_triplets.append(triplet)
     if not all_triplets:
@@ -323,7 +323,7 @@ def tableviews_to_triplet(tableviews, multivalue=False):
     return pl.concat(all_triplets)
 
 
-def tableview_to_triplet(data, multivalue=False):
+def tableview_to_triplets(data, multivalue=False):
     """Convert a table view back to triplet format."""
     # polars melt (unpivot)
     id_col = "ID" if "ID" in data.columns else data.columns[0]
@@ -347,7 +347,7 @@ def tableview_to_triplet(data, multivalue=False):
     return triplet_df.cast({"VALUE": pl.Utf8, "KEY": pl.Utf8, "ID": pl.Utf8})
 
 
-def update_triplet_from_triplet(data, update_data, update=True, add=True):
+def update_triplets_from_triplets(data, update_data, update=True, add=True):
     """Update triplet data with values from another triplet dataset."""
     if update:
         # Anti-join to remove old values, then concat new ones
@@ -361,20 +361,20 @@ def update_triplet_from_triplet(data, update_data, update=True, add=True):
     return data
 
 
-def update_triplet_from_tableview(data, tableview, update=True, add=True, instance_id=None):
+def update_triplets_from_tableview(data, tableview, update=True, add=True, instance_id=None):
     """Update triplet data from a tableview DataFrame."""
-    triplet = tableview_to_triplet(tableview)
+    triplet = tableview_to_triplets(tableview)
     if instance_id:
         triplet = triplet.with_columns(pl.lit(instance_id).alias("INSTANCE_ID"))
-    return update_triplet_from_triplet(data, triplet, update=update, add=add)
+    return update_triplets_from_triplets(data, triplet, update=update, add=add)
 
 
-def remove_triplet_from_triplet(from_triplet, what_triplet, columns=["ID", "KEY", "VALUE"]):
+def remove_triplets_from_triplets(from_triplet, what_triplet, columns=["ID", "KEY", "VALUE"]):
     """Remove rows from one triplet that match another (anti-join)."""
     return from_triplet.join(what_triplet.select(columns), on=columns, how="anti")
 
 
-def diff_between_triplet(old_data, new_data):
+def diff_triplets(old_data, new_data):
     """Find differences between two triplet datasets."""
     # Rows in old but not in new
     removed = old_data.join(
@@ -393,29 +393,29 @@ def diff_between_triplet(old_data, new_data):
     return pl.concat([removed, added])
 
 
-def diff_between_INSTANCE(data, INSTANCE_ID_1, INSTANCE_ID_2):
+def diff_triplets_by_instance(data, INSTANCE_ID_1, INSTANCE_ID_2):
     """Find differences between two instances in the same dataset."""
     data1 = data.filter(pl.col("INSTANCE_ID") == INSTANCE_ID_1)
     data2 = data.filter(pl.col("INSTANCE_ID") == INSTANCE_ID_2)
-    return diff_between_triplet(data1, data2)
+    return diff_triplets(data1, data2)
 
 
-def print_triplet_diff(old_data, new_data, file_id_object="Distribution", file_id_key="label", exclude_objects=None):
+def print_triplets_diff(old_data, new_data, file_id_object="Distribution", file_id_key="label", exclude_objects=None):
     """Print a human-readable diff between two triplet datasets."""
-    diff = diff_between_triplet(old_data, new_data)
+    diff = diff_triplets(old_data, new_data)
     diff = diff.sort(["ID", "KEY"])
 
     # Remove file identification objects
-    file_ids = filter_by_type(diff, file_id_object)
+    file_ids = filter_triplets_by_type(diff, file_id_object)
     if not file_ids.is_empty():
-        diff = remove_triplet_from_triplet(diff, file_ids)
+        diff = remove_triplets_from_triplets(diff, file_ids)
 
     # Exclude specified types
     if exclude_objects:
         for obj in exclude_objects:
-            obj_data = filter_by_type(diff, obj)
+            obj_data = filter_triplets_by_type(diff, obj)
             if not obj_data.is_empty():
-                diff = remove_triplet_from_triplet(diff, obj_data)
+                diff = remove_triplets_from_triplets(diff, obj_data)
 
     if diff.is_empty():
         print("No differences found")


### PR DESCRIPTION
Implements the naming convention agreed in the review: `<action>_<format>_<qualifier>`, where the format token is **`triplets`** (long ID/KEY/VALUE/INSTANCE_ID table, always plural) or **`tableview`** (pivoted per-class table).

## 13 renames

| Old | New | Why |
|-----|-----|-----|
| `filter_by_type` | `filter_triplets_by_type` | says what is filtered |
| `filter_by_triplet` | `filter_triplets_by_triplets` | |
| `set_VALUE_at_KEY` | `set_triplets_value_by_key` | no caps |
| `set_VALUE_at_KEY_and_ID` | `set_triplets_value_by_key_and_id` | |
| `diff_between_INSTANCE` | `diff_triplets_by_instance` | |
| `diff_between_triplet` | `diff_triplets` | |
| `print_triplet_diff` | `print_triplets_diff` | plural consistency |
| `update_triplet_from_triplet` | `update_triplets_from_triplets` | |
| `update_triplet_from_tableview` | `update_triplets_from_tableview` | |
| `remove_triplet_from_triplet` | `remove_triplets_from_triplets` | |
| `triplet_to_tableviews` | `triplets_to_tableviews` | |
| `tableview_to_triplet` | `tableview_to_triplets` | |
| `tableviews_to_triplet` | `tableviews_to_triplets` | |

Renamed everywhere: all three engines (pandas/polars/duckdb), the tools dispatcher, DataFrame monkey-patches, `df.triplets.*` accessors (pandas + polars), CLI tools, cgmes_tools call sites, README examples, and tests.

## Backwards compatibility

- `tools.DEPRECATED_ALIASES` registry: every old name keeps working at module level, as a DataFrame method, and as an accessor method — all emit `DeprecationWarning` pointing at the new name. Removal in 0.2.
- `rdf_parser.py` keeps its 0.0 names unchanged (it is the deprecated surface already) and delegates to the new tools names.
- DataFrame monkey-patch block rewritten as a registry loop (`DATAFRAME_METHODS` + aliases) instead of 22 hand-written lambdas.
- Migration guide updated with the rename table in both copies.

Note: DuckDB connections expose only the new names (`con.filter_triplets_by_type`) — the DuckDB API has never been in a stable release, so no aliases there.

Tests: new `TestToolsDeprecatedAliases` (module/DataFrame/accessor alias warnings + registry resolution); full suite 134 passed, 44 skipped, 1 known xfail.