### PR TITLE
fix: plain category for dictionary columns — pandas 2.2.x compat

### DIFF
--- a/docs/migration_0.0_to_0.1.md
+++ b/docs/migration_0.0_to_0.1.md
@@ -19,7 +19,7 @@ graph = data.export_to_networkx()
 ### Arrow-backed dtypes (when using pyarrow engines)
 
 When `triplets[arrow]` is installed, the `python_lxml_arrow` and `cython_pugixml_arrow` engines
-return DataFrames with `string[pyarrow]` and `dictionary<...>[pyarrow]` column dtypes instead of
+return DataFrames with `string[pyarrow]` and `category` column dtypes instead of
 plain `object`/`str`.
 
 This affects code that:
@@ -50,7 +50,7 @@ This saves ~60% memory but may affect code that expects plain string columns:
 
 ```python
 # Check if a column is categorical
-print(data["KEY"].dtype)  # dictionary<values=string, indices=int32, ordered=0>[pyarrow]
+print(data["KEY"].dtype)  # category (dictionary-encoded)
 
 # Convert to plain strings if needed
 data["KEY"] = data["KEY"].astype(str)

--- a/docs/source/guides/migration_0.0_to_0.1.md
+++ b/docs/source/guides/migration_0.0_to_0.1.md
@@ -19,7 +19,7 @@ graph = data.export_to_networkx()
 ### Arrow-backed dtypes (when using pyarrow engines)
 
 When `triplets[arrow]` is installed, the `python_lxml_arrow` and `cython_pugixml_arrow` engines
-return DataFrames with `string[pyarrow]` and `dictionary<...>[pyarrow]` column dtypes instead of
+return DataFrames with `string[pyarrow]` and `category` column dtypes instead of
 plain `object`/`str`.
 
 This affects code that:
@@ -50,7 +50,7 @@ This saves ~60% memory but may affect code that expects plain string columns:
 
 ```python
 # Check if a column is categorical
-print(data["KEY"].dtype)  # dictionary<values=string, indices=int32, ordered=0>[pyarrow]
+print(data["KEY"].dtype)  # category (dictionary-encoded)
 
 # Convert to plain strings if needed
 data["KEY"] = data["KEY"].astype(str)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -81,6 +81,20 @@ def test_categorical_encoding(parser_engine, use_cat):
         assert df["KEY"].nunique() < 20
 
 
+def test_categorical_columns_are_plain_category(parser_engine):
+    """KEY/INSTANCE_ID must be plain pandas category, NOT ArrowDtype dictionary —
+    ArrowDtype dictionary columns break pivot() on pandas 2.2.x
+    ("'Series' object has no attribute '_pa_array'")."""
+    import pandas
+    df = parse(MINIMAL, engine=parser_engine, return_type="pandas")
+    for column in ("KEY", "INSTANCE_ID"):
+        assert isinstance(df[column].dtype, pandas.CategoricalDtype), \
+            f"{column} is {df[column].dtype}, expected category"
+    # pivot is the operation that crashed on ArrowDtype dictionary columns
+    pivoted = df.drop_duplicates(["ID", "KEY"]).pivot(index="ID", columns="KEY")["VALUE"]
+    assert len(pivoted) > 0
+
+
 # ── Return types ────────────────────────────────────────────────────────────
 
 def test_parse_returns_arrow_and_polars():

--- a/triplets/parser/__init__.py
+++ b/triplets/parser/__init__.py
@@ -176,8 +176,15 @@ def _finalize_arrow(batches, return_type, categorical_columns, debug):
 
     if return_type == "pandas":
         import pandas as pd
+
+        def _dtype_mapper(arrow_type):
+            # Dictionary columns become plain pandas Categorical (None = pyarrow default),
+            # matching the pandas-engine path. ArrowDtype dictionary columns break e.g.
+            # pivot() on pandas 2.2.x ("'Series' object has no attribute '_pa_array'").
+            return None if pa.types.is_dictionary(arrow_type) else pd.ArrowDtype(arrow_type)
+
         try:
-            return table.to_pandas(types_mapper=pd.ArrowDtype)  # zero-copy, Arrow-backed dtypes
+            return table.to_pandas(types_mapper=_dtype_mapper)  # zero-copy, Arrow-backed dtypes
         except Exception:
             return table.to_pandas()
     if return_type == "arrow":


### PR DESCRIPTION
Arrow engines returned KEY/INSTANCE_ID as ArrowDtype dictionary columns
(dictionary<...>[pyarrow]). pandas 2.2.x crashes on pivot() over such
columns ("'Series' object has no attribute '_pa_array'", fixed upstream
in later pandas) — breaking type_tableview & friends for any user not
on the newest pandas.

The to_pandas types_mapper now sends dictionary columns through the
pyarrow default conversion (plain pandas Categorical) and keeps
ArrowDtype for everything else. Bonus: arrow and pandas engine paths
now produce the same dtypes (category), instead of two different
categorical flavors.

Verified against pandas 2.0.3, 2.1.4, 2.2.3 and 3.0.3.
