### PR TITLE
refactor: set_triplets_value_at_key — restore "at" from the original name

### DIFF
--- a/docs/migration_0.0_to_0.1.md
+++ b/docs/migration_0.0_to_0.1.md
@@ -86,8 +86,8 @@ Old names keep working but emit `DeprecationWarning`; they will be removed in 0.
 |-----------|-----------|
 | `filter_by_type` | `filter_triplets_by_type` |
 | `filter_by_triplet` | `filter_triplets_by_triplets` |
-| `set_VALUE_at_KEY` | `set_triplets_value_by_key` |
-| `set_VALUE_at_KEY_and_ID` | `set_triplets_value_by_key_and_id` |
+| `set_VALUE_at_KEY` | `set_triplets_value_at_key` |
+| `set_VALUE_at_KEY_and_ID` | `set_triplets_value_at_key_and_id` |
 | `update_triplet_from_triplet` | `update_triplets_from_triplets` |
 | `update_triplet_from_tableview` | `update_triplets_from_tableview` |
 | `remove_triplet_from_triplet` | `remove_triplets_from_triplets` |
@@ -97,6 +97,10 @@ Old names keep working but emit `DeprecationWarning`; they will be removed in 0.
 | `diff_between_triplet` | `diff_triplets` |
 | `diff_between_INSTANCE` | `diff_triplets_by_instance` |
 | `print_triplet_diff` | `print_triplets_diff` |
+
+> Note: 0.1.0rc4 briefly shipped these two as `set_triplets_value_by_key(_and_id)`;
+> corrected to `_at_` before 0.1.0. The `_by_` spellings keep working with a
+> `DeprecationWarning`.
 
 The renames apply to `triplets.tools.*`, the DataFrame methods, and the
 `df.triplets.*` accessor alike.
@@ -111,6 +115,24 @@ Old names keep working in 0.1 but emit `DeprecationWarning`; they will be remove
 | `cgmes_tools.statistics_GeneratingUnit_types` | `cgmes_tools.count_GeneratingUnit_types` |
 | `cgmes_tools.generate_instances_ID` | `cgmes_tools.generate_instance_ids` |
 | `cgmes_tools.get_model_data` | `cgmes_tools.get_model_triplets` |
+
+### Triplets are always strings (or null)
+
+Since 0.1, the tools enforce that `ID`/`KEY`/`VALUE` contain only strings or
+nulls — never raw numbers or other objects:
+
+- `tableview_to_triplets` (and the tableview update functions built on it)
+  returns a nullable `string` dtype: numbers from `string_to_number=True`
+  tableviews become text, and empty tableview cells stay **null** — previously
+  they became literal `"nan"` strings.
+- `set_triplets_value_at_key` / `set_triplets_value_at_key_and_id` normalize
+  values with `str()`; `None` stays null (previously polars stored the literal
+  string `"None"`, and pandas let raw ints into `VALUE` — which crashed the
+  compiled CIM XML export with `Expected bytes, got a 'int' object`).
+
+If your code built triplet rows with numeric `VALUE`s by hand, the exports now
+tolerate them, but converting with `data["VALUE"].astype(str)` keeps your data
+within the contract.
 
 ### DataFrame methods
 

--- a/docs/source/guides/migration_0.0_to_0.1.md
+++ b/docs/source/guides/migration_0.0_to_0.1.md
@@ -86,8 +86,8 @@ Old names keep working but emit `DeprecationWarning`; they will be removed in 0.
 |-----------|-----------|
 | `filter_by_type` | `filter_triplets_by_type` |
 | `filter_by_triplet` | `filter_triplets_by_triplets` |
-| `set_VALUE_at_KEY` | `set_triplets_value_by_key` |
-| `set_VALUE_at_KEY_and_ID` | `set_triplets_value_by_key_and_id` |
+| `set_VALUE_at_KEY` | `set_triplets_value_at_key` |
+| `set_VALUE_at_KEY_and_ID` | `set_triplets_value_at_key_and_id` |
 | `update_triplet_from_triplet` | `update_triplets_from_triplets` |
 | `update_triplet_from_tableview` | `update_triplets_from_tableview` |
 | `remove_triplet_from_triplet` | `remove_triplets_from_triplets` |
@@ -97,6 +97,10 @@ Old names keep working but emit `DeprecationWarning`; they will be removed in 0.
 | `diff_between_triplet` | `diff_triplets` |
 | `diff_between_INSTANCE` | `diff_triplets_by_instance` |
 | `print_triplet_diff` | `print_triplets_diff` |
+
+> Note: 0.1.0rc4 briefly shipped these two as `set_triplets_value_by_key(_and_id)`;
+> corrected to `_at_` before 0.1.0. The `_by_` spellings keep working with a
+> `DeprecationWarning`.
 
 The renames apply to `triplets.tools.*`, the DataFrame methods, and the
 `df.triplets.*` accessor alike.
@@ -111,6 +115,24 @@ Old names keep working in 0.1 but emit `DeprecationWarning`; they will be remove
 | `cgmes_tools.statistics_GeneratingUnit_types` | `cgmes_tools.count_GeneratingUnit_types` |
 | `cgmes_tools.generate_instances_ID` | `cgmes_tools.generate_instance_ids` |
 | `cgmes_tools.get_model_data` | `cgmes_tools.get_model_triplets` |
+
+### Triplets are always strings (or null)
+
+Since 0.1, the tools enforce that `ID`/`KEY`/`VALUE` contain only strings or
+nulls — never raw numbers or other objects:
+
+- `tableview_to_triplets` (and the tableview update functions built on it)
+  returns a nullable `string` dtype: numbers from `string_to_number=True`
+  tableviews become text, and empty tableview cells stay **null** — previously
+  they became literal `"nan"` strings.
+- `set_triplets_value_at_key` / `set_triplets_value_at_key_and_id` normalize
+  values with `str()`; `None` stays null (previously polars stored the literal
+  string `"None"`, and pandas let raw ints into `VALUE` — which crashed the
+  compiled CIM XML export with `Expected bytes, got a 'int' object`).
+
+If your code built triplet rows with numeric `VALUE`s by hand, the exports now
+tolerate them, but converting with `data["VALUE"].astype(str)` keeps your data
+within the contract.
 
 ### DataFrame methods
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -211,7 +211,7 @@ class TestFilterByTriplet:
 class TestSetValueAtKey:
     def test_modifies_data(self, svedala_eq):
         data = svedala_eq.copy()
-        data.set_triplets_value_by_key("Model.description", "test_value")
+        data.set_triplets_value_at_key("Model.description", "test_value")
         modified = data[data["KEY"] == "Model.description"]["VALUE"]
         if len(modified) > 0:
             assert all(v == "test_value" for v in modified.values)
@@ -221,7 +221,7 @@ class TestSetValueAtKeyAndID:
     def test_modifies_specific_row(self, svedala_data):
         data = svedala_data.copy()
         target = data[(data["KEY"] == "Type") & (data["VALUE"] == "Substation")].iloc[0]
-        data.set_triplets_value_by_key_and_id("Type", "TestType", target["ID"])
+        data.set_triplets_value_at_key_and_id("Type", "TestType", target["ID"])
         modified = data[(data["ID"] == target["ID"]) & (data["KEY"] == "Type")]
         assert modified["VALUE"].iloc[0] == "TestType"
 
@@ -334,7 +334,7 @@ class TestToolsDeprecatedAliases:
         assert len(result) > 0
 
     def test_dataframe_method_alias_warns(self, svedala_data):
-        with pytest.warns(DeprecationWarning, match="set_triplets_value_by_key"):
+        with pytest.warns(DeprecationWarning, match="set_triplets_value_at_key"):
             svedala_data.copy().set_VALUE_at_KEY("Model.description", "x")
 
     def test_accessor_alias_warns(self, svedala_data):
@@ -373,10 +373,10 @@ class TestTripletsStringInvariant:
         if engine == "polars":
             polars = pytest.importorskip("polars")
             data = polars.from_pandas(frame)
-            result = triplets.tools.set_triplets_value_by_key(data, "k", 42)
+            result = triplets.tools.set_triplets_value_at_key(data, "k", 42)
             assert result["VALUE"][0] == "42"
         else:
-            triplets.tools.set_triplets_value_by_key(frame, "k", 42)
+            triplets.tools.set_triplets_value_at_key(frame, "k", 42)
             assert frame["VALUE"].iloc[0] == "42"
 
     @pytest.mark.parametrize("engine", ["pandas", "polars"])
@@ -385,10 +385,10 @@ class TestTripletsStringInvariant:
         if engine == "polars":
             polars = pytest.importorskip("polars")
             data = polars.from_pandas(frame)
-            result = triplets.tools.set_triplets_value_by_key(data, "k", None)
+            result = triplets.tools.set_triplets_value_at_key(data, "k", None)
             assert result["VALUE"][0] is None         # not the string "None"
         else:
-            triplets.tools.set_triplets_value_by_key(frame, "k", None)
+            triplets.tools.set_triplets_value_at_key(frame, "k", None)
             assert pandas.isna(frame["VALUE"].iloc[0])
 
 

--- a/triplets/_accessor.py
+++ b/triplets/_accessor.py
@@ -48,7 +48,7 @@ PANDAS_TOOL_METHODS = [
     # filter
     "filter_triplets_by_type", "filter_triplets_by_triplets", "filter_triplets",
     # mutate
-    "set_triplets_value_by_key", "set_triplets_value_by_key_and_id",
+    "set_triplets_value_at_key", "set_triplets_value_at_key_and_id",
     "update_triplets_from_triplets", "update_triplets_from_tableview",
     # transform
     "triplets_to_tableviews", "tableview_to_triplets",

--- a/triplets/cli/cim_spreadsheet.py
+++ b/triplets/cli/cim_spreadsheet.py
@@ -361,9 +361,9 @@ def spreadsheet_to_cim(input_path, output_path, format=None, rdf_map=None,
     version = get_versions()['version']
     tool_version = f"triplets-{version}"
     # Old header (md:FullModel) uses Model.applicationSoftware
-    data.set_triplets_value_by_key("Model.applicationSoftware", tool_version)
+    data.set_triplets_value_at_key("Model.applicationSoftware", tool_version)
     # New header (dcat:Dataset) uses applicationSoftware (eumd namespace)
-    data.set_triplets_value_by_key("applicationSoftware", tool_version)
+    data.set_triplets_value_at_key("applicationSoftware", tool_version)
 
     if "INSTANCE_ID" not in data.columns or data["INSTANCE_ID"].isna().all():
         data["INSTANCE_ID"] = str(uuid4())

--- a/triplets/rdf_parser.py
+++ b/triplets/rdf_parser.py
@@ -420,16 +420,16 @@ def filter_by_triplet(data, filter_triplet):
 
 
 def set_VALUE_at_KEY(data, key, value):
-    """Deprecated: use triplets.tools.set_triplets_value_by_key()"""
-    warnings.warn("rdf_parser.set_VALUE_at_KEY is deprecated, use triplets.tools.set_triplets_value_by_key()", DeprecationWarning, stacklevel=2)
-    from .tools import set_triplets_value_by_key as _fn
+    """Deprecated: use triplets.tools.set_triplets_value_at_key()"""
+    warnings.warn("rdf_parser.set_VALUE_at_KEY is deprecated, use triplets.tools.set_triplets_value_at_key()", DeprecationWarning, stacklevel=2)
+    from .tools import set_triplets_value_at_key as _fn
     return _fn(data, key, value)
 
 
 def set_VALUE_at_KEY_and_ID(data, key, value, id):
-    """Deprecated: use triplets.tools.set_triplets_value_by_key_and_id()"""
-    warnings.warn("rdf_parser.set_VALUE_at_KEY_and_ID is deprecated, use triplets.tools.set_triplets_value_by_key_and_id()", DeprecationWarning, stacklevel=2)
-    from .tools import set_triplets_value_by_key_and_id as _fn
+    """Deprecated: use triplets.tools.set_triplets_value_at_key_and_id()"""
+    warnings.warn("rdf_parser.set_VALUE_at_KEY_and_ID is deprecated, use triplets.tools.set_triplets_value_at_key_and_id()", DeprecationWarning, stacklevel=2)
+    from .tools import set_triplets_value_at_key_and_id as _fn
     return _fn(data, key, value, id)
 
 

--- a/triplets/tools/__init__.py
+++ b/triplets/tools/__init__.py
@@ -95,11 +95,11 @@ def filter_triplets_by_triplets(data, filter_triplet, engine="auto"):
 def filter_triplets(data, ID=None, KEY=None, VALUE=None, INSTANCE_ID=None, regex=False, engine="auto"):
     return _get_engine(engine, data).filter_triplets(data, ID=ID, KEY=KEY, VALUE=VALUE, INSTANCE_ID=INSTANCE_ID, regex=regex)
 
-def set_triplets_value_by_key(data, key, value, engine="auto"):
-    return _get_engine(engine, data).set_triplets_value_by_key(data, key, value)
+def set_triplets_value_at_key(data, key, value, engine="auto"):
+    return _get_engine(engine, data).set_triplets_value_at_key(data, key, value)
 
-def set_triplets_value_by_key_and_id(data, key, value, id, engine="auto"):
-    return _get_engine(engine, data).set_triplets_value_by_key_and_id(data, key, value, id)
+def set_triplets_value_at_key_and_id(data, key, value, id, engine="auto"):
+    return _get_engine(engine, data).set_triplets_value_at_key_and_id(data, key, value, id)
 
 def triplets_to_tableviews(triplet_df, multivalue=False, engine="auto"):
     return _get_engine(engine, triplet_df).triplets_to_tableviews(triplet_df, multivalue=multivalue)
@@ -153,8 +153,8 @@ for _alias, _target in ALIASES.items():
 DEPRECATED_ALIASES = {
     "filter_by_type": "filter_triplets_by_type",
     "filter_by_triplet": "filter_triplets_by_triplets",
-    "set_VALUE_at_KEY": "set_triplets_value_by_key",
-    "set_VALUE_at_KEY_and_ID": "set_triplets_value_by_key_and_id",
+    "set_VALUE_at_KEY": "set_triplets_value_at_key",
+    "set_VALUE_at_KEY_and_ID": "set_triplets_value_at_key_and_id",
     "update_triplet_from_triplet": "update_triplets_from_triplets",
     "update_triplet_from_tableview": "update_triplets_from_tableview",
     "remove_triplet_from_triplet": "remove_triplets_from_triplets",
@@ -164,6 +164,9 @@ DEPRECATED_ALIASES = {
     "diff_between_triplet": "diff_triplets",
     "diff_between_INSTANCE": "diff_triplets_by_instance",
     "print_triplet_diff": "print_triplets_diff",
+    # 0.1.0rc4 briefly named these _by_; corrected to _at_ before 0.1.0
+    "set_triplets_value_by_key": "set_triplets_value_at_key",
+    "set_triplets_value_by_key_and_id": "set_triplets_value_at_key_and_id",
 }
 
 
@@ -191,7 +194,7 @@ DATAFRAME_METHODS = [
     "references_to_simple", "references_to", "references_from_simple",
     "references_from", "references_all", "references_simple", "references",
     "filter_triplets_by_type", "filter_triplets_by_triplets", "filter_triplets",
-    "set_triplets_value_by_key", "set_triplets_value_by_key_and_id",
+    "set_triplets_value_at_key", "set_triplets_value_at_key_and_id",
     "tableview_to_triplets", "update_triplets_from_triplets",
     "update_triplets_from_tableview", "diff_triplets_by_instance",
 ]

--- a/triplets/tools/pandas_engine.py
+++ b/triplets/tools/pandas_engine.py
@@ -537,7 +537,7 @@ def _string_or_none(value):
     return None if value is None else str(value)
 
 
-def set_triplets_value_by_key(data, key, value):
+def set_triplets_value_at_key(data, key, value):
     """Set the value for all instances of a specified key.
 
     Parameters
@@ -556,12 +556,12 @@ def set_triplets_value_by_key(data, key, value):
 
     Examples
     --------
-    >>> data.set_triplets_value_by_key("label", "new_label")
+    >>> data.set_triplets_value_at_key("label", "new_label")
     """
     data.loc[data[data.KEY == key].index, "VALUE"] = _string_or_none(value)  # TODO add changes to change DataFrame
 
 
-def set_triplets_value_by_key_and_id(data, key, value, id):
+def set_triplets_value_at_key_and_id(data, key, value, id):
     """Set the value for a specific key and ID.
 
     Parameters
@@ -577,7 +577,7 @@ def set_triplets_value_by_key_and_id(data, key, value, id):
 
     Examples
     --------
-    >>> data.set_triplets_value_by_key_and_id("label", "new_label", "uuid1")
+    >>> data.set_triplets_value_at_key_and_id("label", "new_label", "uuid1")
     """
     data.loc[data[(data.ID == id) & (data.KEY == key)].index, "VALUE"] = _string_or_none(value)
 

--- a/triplets/tools/polars_engine.py
+++ b/triplets/tools/polars_engine.py
@@ -283,7 +283,7 @@ def _value_literal(value):
     return pl.lit(None, dtype=pl.Utf8) if value is None else pl.lit(str(value))
 
 
-def set_triplets_value_by_key(data, key, value):
+def set_triplets_value_at_key(data, key, value):
     """Set VALUE for all rows with a given KEY (in-place mutation via reassignment)."""
     return data.with_columns(
         pl.when(pl.col("KEY") == key)
@@ -293,7 +293,7 @@ def set_triplets_value_by_key(data, key, value):
     )
 
 
-def set_triplets_value_by_key_and_id(data, key, value, id):
+def set_triplets_value_at_key_and_id(data, key, value, id):
     """Set VALUE for a specific KEY and ID combination."""
     return data.with_columns(
         pl.when((pl.col("KEY") == key) & (pl.col("ID") == id))


### PR DESCRIPTION
set_VALUE_at_KEY was renamed to set_triplets_value_by_key in #45;
"at" was the right preposition (value AT a key, not BY). Renamed to
set_triplets_value_at_key(_and_id) everywhere; the rc4 _by_ spellings
keep working as DeprecationWarning aliases.

Migration guide updated: corrected rename table + note about the rc4
naming, and a new section documenting the strings-or-null triplets
invariant from #56 (nullable string roundtrips, set-value
normalization).
