### PR TITLE
fix: remove pandas.DataFrame.changes class attribute

### DIFF
--- a/triplets/rdf_parser.py
+++ b/triplets/rdf_parser.py
@@ -576,9 +576,6 @@ pandas.DataFrame.export_to_cimxml = export_to_cimxml
 pandas.DataFrame.export_to_networkx = export_to_networkx
 pandas.filter_triplet_by_triplet = filter_by_triplet
 
-# Let's add empty dataframe to keep changes
-pandas.DataFrame.changes = pandas.DataFrame()
-
 
 # TEST AND EXAMPLES
 if __name__ == '__main__':

--- a/triplets/tools/__init__.py
+++ b/triplets/tools/__init__.py
@@ -207,5 +207,3 @@ def _dataframe_method(function):
 
 for _name in DATAFRAME_METHODS + list(ALIASES) + list(DEPRECATED_ALIASES):
     setattr(pandas.DataFrame, _name, _dataframe_method(globals()[_name]))
-
-pandas.DataFrame.changes = pandas.DataFrame()


### PR DESCRIPTION
Closes #60

A mutable empty DataFrame shared as a class attribute by every
DataFrame in the process — leftover of an unbuilt change-tracking idea
(UI system with backend edit tracking). If change tracking returns it
will be designed per-frame and opt-in.
