### PR TITLE
refactor: unify tableview functions — shared core, multivalue everywhere

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -89,6 +89,19 @@ class TestKeyTableview:
         tv = svedala_data.key_tableview("NonExistent.key")
         assert tv is None
 
+    def test_multivalue(self, svedala_data):
+        # FullModel has multiple Model.DependentOn values per ID
+        tv = svedala_data.key_tableview("Model.DependentOn", multivalue=True, string_to_number=False)
+        assert tv is not None
+        assert any(isinstance(v, list) for v in tv["Model.DependentOn"])
+
+    def test_multivalue_polars_parity(self, svedala_data):
+        polars = pytest.importorskip("polars")
+        pd_tv = svedala_data.key_tableview("Model.DependentOn", multivalue=True, string_to_number=False)
+        pl_tv = triplets.tools.key_tableview(
+            polars.from_pandas(svedala_data), "Model.DependentOn", multivalue=True, string_to_number=False)
+        assert len(pd_tv) == len(pl_tv)
+
 
 class TestIdTableview:
     def test_returns_dataframe(self, svedala_data):
@@ -98,6 +111,20 @@ class TestIdTableview:
         tv = triplets.rdf_parser.id_tableview(svedala_data, sub_id)
         assert isinstance(tv, pandas.DataFrame)
         assert len(tv) > 0
+
+    def test_list_input_and_multivalue(self, svedala_data):
+        subs = svedala_data[(svedala_data["KEY"] == "Type") & (svedala_data["VALUE"] == "Substation")]
+        ids = list(subs["ID"].iloc[:3])
+        tv = svedala_data.id_tableview(ids, multivalue=True, string_to_number=False)
+        assert len(tv) == 3
+
+    def test_list_input_polars_parity(self, svedala_data):
+        polars = pytest.importorskip("polars")
+        subs = svedala_data[(svedala_data["KEY"] == "Type") & (svedala_data["VALUE"] == "Substation")]
+        ids = list(subs["ID"].iloc[:3])
+        pd_tv = svedala_data.id_tableview(ids, string_to_number=False)
+        pl_tv = triplets.tools.id_tableview(polars.from_pandas(svedala_data), ids, string_to_number=False)
+        assert len(pd_tv) == len(pl_tv) == 3
 
 
 class TestTypesDict:

--- a/triplets/tools/__init__.py
+++ b/triplets/tools/__init__.py
@@ -50,11 +50,11 @@ def _get_engine(engine, data=None):
 def type_tableview(data, type_name, string_to_number=True, type_key="Type", multivalue=False, engine="auto"):
     return _get_engine(engine, data).type_tableview(data, type_name, string_to_number=string_to_number, type_key=type_key, multivalue=multivalue)
 
-def key_tableview(data, key, string_to_number=True, engine="auto"):
-    return _get_engine(engine, data).key_tableview(data, key, string_to_number=string_to_number)
+def key_tableview(data, key, string_to_number=True, multivalue=False, engine="auto"):
+    return _get_engine(engine, data).key_tableview(data, key, string_to_number=string_to_number, multivalue=multivalue)
 
-def id_tableview(data, id, string_to_number=True, engine="auto"):
-    return _get_engine(engine, data).id_tableview(data, id, string_to_number=string_to_number)
+def id_tableview(data, id, string_to_number=True, multivalue=False, engine="auto"):
+    return _get_engine(engine, data).id_tableview(data, id, string_to_number=string_to_number, multivalue=multivalue)
 
 def types_dict(data, engine="auto"):
     return _get_engine(engine, data).types_dict(data)

--- a/triplets/tools/pandas_engine.py
+++ b/triplets/tools/pandas_engine.py
@@ -74,6 +74,42 @@ def get_namespace_map(data: pandas.DataFrame):
     return namespace_map, xml_base
 
 
+def _numeric_columns(data_view):
+    """Convert columns that contain only numbers to numeric dtypes."""
+    for column in data_view.columns:
+        try:
+            data_view[column] = pandas.to_numeric(data_view[column], errors="raise")
+        except (ValueError, TypeError):
+            pass
+    return data_view
+
+
+def _tableview(rows, data, string_to_number, multivalue, label):
+    """Shared pivot core for the three tableview functions.
+
+    rows: triplet rows whose IDs select the objects; data: full dataset
+    providing all triplets of the selected objects.
+    """
+    if rows.empty:
+        logger.warning(f'No data available for {label}')
+        return None
+
+    object_data = pandas.merge(rows[["ID"]].drop_duplicates(), data, on="ID")
+
+    if multivalue:
+        def _aggregate(x):
+            x_list = list(x)
+            if len(x_list) == 1:
+                return x_list[0]
+            return x_list
+
+        data_view = object_data.pivot_table(index="ID", columns="KEY", values="VALUE", aggfunc=_aggregate)
+    else:
+        data_view = object_data.drop_duplicates(["ID", "KEY"]).pivot(index="ID", columns="KEY")["VALUE"]
+
+    return _numeric_columns(data_view) if string_to_number else data_view
+
+
 def type_tableview(data, type_name, string_to_number=True, type_key="Type", multivalue=False):
     """Create a table view of all objects of a specified type.
 
@@ -99,40 +135,11 @@ def type_tableview(data, type_name, string_to_number=True, type_key="Type", mult
     --------
     >>> table = data.type_tableview("ACLineSegment", multivalue=True)
     """
-    # Get all ID-s of rows where Type == type_name
-    type_id = data[(data["VALUE"] == type_name) & (data["KEY"] == type_key)]
-
-    if type_id.empty:
-        logger.warning(f'No data available for {type_name}')
-        return None
-
-    # Filter original data by found type_id data
-    type_data = pandas.merge(type_id[["ID"]], data, on="ID")
-
-    # Convert from triplets to a table view of all objects of same type
-    if multivalue:
-        def _aggregate(x):
-            x_list = list(x)
-            if len(x_list) == 1:
-                return x_list[0]
-            return x_list
-
-        data_view = type_data.pivot_table(index="ID", columns="KEY", values="VALUE", aggfunc=_aggregate)
-    else:
-        type_data = type_data.drop_duplicates(["ID", "KEY"])
-        data_view = type_data.pivot(index="ID", columns="KEY")["VALUE"]
-
-    if string_to_number:
-        for column in data_view.columns:
-            try:
-                data_view[column] = pandas.to_numeric(data_view[column], errors="raise")
-            except (ValueError, TypeError):
-                pass
-
-    return data_view
+    rows = data[(data["VALUE"] == type_name) & (data["KEY"] == type_key)]
+    return _tableview(rows, data, string_to_number, multivalue, type_name)
 
 
-def key_tableview(data, key, string_to_number=True):
+def key_tableview(data, key, string_to_number=True, multivalue=False):
     """Create a table view of all objects with a specified key.
 
     Parameters
@@ -143,6 +150,8 @@ def key_tableview(data, key, string_to_number=True):
         The key to filter objects by (e.g., 'GeneratingUnit.maxOperatingP').
     string_to_number : bool, optional
         If True, convert columns containing numbers to numeric types (default is True).
+    multivalue : bool, optional
+        If True, aggregate duplicate (ID, KEY) pairs into lists (default is False).
 
     Returns
     -------
@@ -153,32 +162,11 @@ def key_tableview(data, key, string_to_number=True):
     --------
     >>> table = data.key_tableview("GeneratingUnit.maxOperatingP")
     """
-    # Get all ID-s of rows where KEY == key_name
-    key_id = data[data["KEY"] == key]
-
-    if key_id.empty:
-        logger.warning(f'No data available for {key}')
-        return None
-
-    # Filter original data by found key_id data
-    # There can't be duplicate ID and KEY pairs for pivot, but this will lose data on full model DependantOn and other info, solution would be to use pivot table function.
-    type_data = pandas.merge(key_id[["ID"]], data, on="ID").drop_duplicates(["ID", "KEY"])
-
-    # Convert form triplets to a table view all objects of same type
-    data_view = type_data.pivot(index="ID", columns="KEY")["VALUE"]
-
-    if string_to_number:
-        # Convert to data type to numeric in columns that contain only numbers (for easier data usage later on)
-        for column in data_view.columns:
-            try:
-                data_view[column] = pandas.to_numeric(data_view[column], errors="raise")
-            except (ValueError, TypeError):
-                pass
-
-    return data_view
+    rows = data[data["KEY"] == key]
+    return _tableview(rows, data, string_to_number, multivalue, key)
 
 
-def id_tableview(data, id, string_to_number=True):
+def id_tableview(data, id, string_to_number=True, multivalue=False):
     """Create a tabular view of a CGMES triplet dataset filtered by ID-s.
 
     Parameters
@@ -186,45 +174,30 @@ def id_tableview(data, id, string_to_number=True):
     data : pandas.DataFrame
         Triplet dataset containing CGMES data.
     id : str or list or pandas.DataFrame
-        DataFrame containing IDs to filter by.
+        ID(s) to filter by (single ID, list of IDs, or DataFrame with an ID column).
     string_to_number : bool, optional
         If True, convert columns containing numbers to numeric types (default is True).
-
+    multivalue : bool, optional
+        If True, aggregate duplicate (ID, KEY) pairs into lists (default is False).
 
     Returns
     -------
-    pandas.DataFrame
+    pandas.DataFrame or None
         Pivoted DataFrame with IDs as index and KEYs as columns.
 
     Examples
     --------
     >>> table = id_tableview(data, 'UUID')
     >>> table = id_tableview(data, ['UUID_1', 'UUID_2'])
-    >>> table = id_tableview(data, pandas.DataFrame({"ID":['UUID_1', 'UUID_2']})
+    >>> table = id_tableview(data, pandas.DataFrame({"ID": ['UUID_1', 'UUID_2']}))
     """
     if isinstance(id, str):
         id = [id]
-
     if isinstance(id, list):
         id = pandas.DataFrame({"ID": id})
 
-    id_data = filter_triplets_by_triplets(data, id)
-
-    if id_data.empty:
-        logger.warning(f'No data available for {id}')
-        return None
-
-    data_view = id_data.drop_duplicates(["ID", "KEY"]).pivot(index="ID", columns ="KEY")["VALUE"]
-
-    if string_to_number:
-        # Convert to data type to numeric in columns that contain only numbers (for easier data usage later on)
-        for column in data_view.columns:
-            try:
-                data_view[column] = pandas.to_numeric(data_view[column], errors="raise")
-            except (ValueError, TypeError):
-                pass
-
-    return data_view
+    rows = data[data["ID"].isin(id["ID"])]
+    return _tableview(rows, data, string_to_number, multivalue, list(id["ID"]))
 
 
 def references_to_simple(data, reference, columns=["Type"]):

--- a/triplets/tools/polars_engine.py
+++ b/triplets/tools/polars_engine.py
@@ -10,27 +10,35 @@ import polars as pl
 logger = logging.getLogger(__name__)
 
 
-def type_tableview(data, type_name, string_to_number=True, type_key="Type", multivalue=False):
-    """Create a table view of all objects of a specified type using polars pivot."""
-    type_ids = data.filter(
-        (pl.col("VALUE") == type_name) & (pl.col("KEY") == type_key)
-    ).select("ID")
+def _numeric_columns(data_view):
+    """Cast columns that contain only numbers to Float64."""
+    for col in data_view.columns:
+        if col == "ID":
+            continue
+        try:
+            data_view = data_view.with_columns(pl.col(col).cast(pl.Float64, strict=True))
+        except (pl.exceptions.InvalidOperationError, pl.exceptions.ComputeError):
+            pass
+    return data_view
 
-    if type_ids.is_empty():
-        logger.warning(f'No data available for {type_name}')
+
+def _tableview(ids, data, string_to_number, multivalue, label):
+    """Shared pivot core for the three tableview functions.
+
+    ids: polars DataFrame with an ID column selecting the objects.
+    """
+    if ids.is_empty():
+        logger.warning(f'No data available for {label}')
         return None
 
-    type_data = type_ids.join(data, on="ID", how="inner")
+    object_data = ids.select("ID").unique().join(data, on="ID", how="inner")
 
     if multivalue:
         # Aggregate all values per (ID, KEY) into lists, then pivot.
-        # After pivot, convert single-element lists back to scalars.
-        agg = type_data.group_by(["ID", "KEY"]).agg(
-            pl.col("VALUE").alias("VALUE")
-        )
+        agg = object_data.group_by(["ID", "KEY"]).agg(pl.col("VALUE").alias("VALUE"))
         data_view = agg.pivot(on="KEY", index="ID", values="VALUE")
         # Unwrap single-element lists to scalars for cleaner output.
-        # Multi-element lists stay as lists (matching pandas multivalue behavior).
+        # Multi-element lists stay joined (matching pandas multivalue behavior).
         for col in data_view.columns:
             if col == "ID":
                 continue
@@ -43,66 +51,32 @@ def type_tableview(data, type_name, string_to_number=True, type_key="Type", mult
                     .alias(col)
                 )
     else:
-        type_data = type_data.unique(subset=["ID", "KEY"], keep="first")
-        data_view = type_data.pivot(on="KEY", index="ID", values="VALUE")
+        data_view = object_data.unique(subset=["ID", "KEY"], keep="first").pivot(on="KEY", index="ID", values="VALUE")
 
-    if string_to_number:
-        for col in data_view.columns:
-            if col == "ID":
-                continue
-            try:
-                data_view = data_view.with_columns(
-                    pl.col(col).cast(pl.Float64, strict=True)
-                )
-            except (pl.exceptions.InvalidOperationError, pl.exceptions.ComputeError):
-                pass
-
-    return data_view
+    return _numeric_columns(data_view) if string_to_number else data_view
 
 
-def key_tableview(data, key, string_to_number=True):
+def type_tableview(data, type_name, string_to_number=True, type_key="Type", multivalue=False):
+    """Create a table view of all objects of a specified type using polars pivot."""
+    ids = data.filter((pl.col("VALUE") == type_name) & (pl.col("KEY") == type_key))
+    return _tableview(ids, data, string_to_number, multivalue, type_name)
+
+
+def key_tableview(data, key, string_to_number=True, multivalue=False):
     """Create a table view of all objects with a specified key."""
-    key_ids = data.filter(pl.col("KEY") == key).select("ID")
-
-    if key_ids.is_empty():
-        logger.warning(f'No data available for key: {key}')
-        return None
-
-    key_data = key_ids.join(data, on="ID", how="inner").unique(subset=["ID", "KEY"], keep="first")
-    data_view = key_data.pivot(on="KEY", index="ID", values="VALUE")
-
-    if string_to_number:
-        for col in data_view.columns:
-            if col == "ID":
-                continue
-            try:
-                data_view = data_view.with_columns(pl.col(col).cast(pl.Float64, strict=True))
-            except (pl.exceptions.InvalidOperationError, pl.exceptions.ComputeError):
-                pass
-
-    return data_view
+    ids = data.filter(pl.col("KEY") == key)
+    return _tableview(ids, data, string_to_number, multivalue, key)
 
 
-def id_tableview(data, id, string_to_number=True):
-    """Create a table view of a specific object by ID."""
-    obj_data = data.filter(pl.col("ID") == id).unique(subset=["ID", "KEY"], keep="first")
+def id_tableview(data, id, string_to_number=True, multivalue=False):
+    """Create a table view of objects by ID (single ID, list of IDs, or DataFrame with ID column)."""
+    if isinstance(id, str):
+        id = [id]
+    if isinstance(id, list):
+        id = pl.DataFrame({"ID": id})
 
-    if obj_data.is_empty():
-        logger.warning(f'No data available for ID: {id}')
-        return None
-
-    data_view = obj_data.pivot(on="KEY", index="ID", values="VALUE")
-
-    if string_to_number:
-        for col in data_view.columns:
-            if col == "ID":
-                continue
-            try:
-                data_view = data_view.with_columns(pl.col(col).cast(pl.Float64, strict=True))
-            except (pl.exceptions.InvalidOperationError, pl.exceptions.ComputeError):
-                pass
-
-    return data_view
+    ids = data.join(id.select("ID"), on="ID", how="semi")
+    return _tableview(ids, data, string_to_number, multivalue, id["ID"].to_list())
 
 
 def types_dict(data):


### PR DESCRIPTION
Closes #61

Both engines get one _tableview() pivot core + one _numeric_columns()
helper; type/key/id_tableview just select the object IDs and delegate.
Removes the 3x duplicated pivot + to_numeric loops per engine.

- multivalue=True now supported on key_tableview and id_tableview
  (was type_tableview only), threaded through the dispatchers
- polars id_tableview accepts a list of IDs or a DataFrame with an ID
  column (was single-ID only), matching pandas
- string_to_number stays inference-based — no schema dependency
  (schema-optional principle)

Tests: key multivalue (Model.DependentOn), id list input + multivalue,
pandas/polars parity for both.
