### PR TITLE
feat: optional rdf:datatype annotations in CIM XML export (python_lxml)

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -565,6 +565,37 @@ class TestExportToCimxml:
         reimported = pandas.read_RDF([result[0]])
         assert reimported.get_types_count()["ACLineSegment"] == svedala_eq.get_types_count()["ACLineSegment"]
 
+    def test_datatypes_flag(self, svedala_eq):
+        """datatypes=True annotates literals with rdf:datatype like the nquads export."""
+        from triplets.export_schema import schemas
+        result = svedala_eq.export_to_cimxml(
+            rdf_map=schemas.ENTSOE_CGMES_2_4_15_552_ED1,
+            export_type="xml_per_instance",
+            export_to_memory=True,
+            datatypes=True,  # engine=auto must steer to python_lxml
+        )
+        xml = result[0].getvalue().decode()
+        assert 'rdf:datatype="http://www.w3.org/2001/XMLSchema#float"' in xml
+        # xsd:string keys stay unannotated (RDF 1.1 default)
+        assert 'IdentifiedObject.name rdf:datatype' not in xml
+
+        # typed output still reimports identically
+        result[0].seek(0)
+        reimported = pandas.read_RDF([result[0]])
+        assert reimported.get_types_count()["ACLineSegment"] == svedala_eq.get_types_count()["ACLineSegment"]
+
+    def test_datatypes_unsupported_on_cython(self, svedala_eq):
+        require_cimxml_engine("cython_pugixml")
+        from triplets.export_schema import schemas
+        with pytest.raises(NotImplementedError, match="python_lxml"):
+            svedala_eq.export_to_cimxml(
+                rdf_map=schemas.ENTSOE_CGMES_2_4_15_552_ED1,
+                export_type="xml_per_instance",
+                export_to_memory=True,
+                engine="cython_pugixml",
+                datatypes=True,
+            )
+
     def test_engines_produce_identical_output(self, svedala_eq):
         require_cimxml_engine("cython_pugixml")
         from triplets.export_schema import schemas

--- a/triplets/export/__init__.py
+++ b/triplets/export/__init__.py
@@ -134,7 +134,8 @@ def export_to_cimxml(data,
                      export_base_path="",
                      comment=None,
                      max_workers=None,
-                     engine="auto"):
+                     engine="auto",
+                     datatypes=False):
     """Export a full triplet dataset to CIM RDF XML files or ZIP archives.
 
     Processes all instances (grouped by ``INSTANCE_ID``) and exports them according to the
@@ -173,6 +174,10 @@ def export_to_cimxml(data,
         XML generation engine. "auto" picks best available.
         Options: "python_lxml" (lxml, always available), "cython_pugixml" (compiled, fastest).
         Aliases: "performance"/"pugixml" → cython_pugixml, "lxml"/"pandas" → python_lxml.
+    datatypes : bool, default False
+        If True, annotate literal elements with rdf:datatype from the schema's
+        xsd:type, like the N-Quads export ("44.84" → rdf:datatype xsd#float;
+        xsd:string stays plain). Currently python_lxml only — "auto" picks it.
 
     Returns
     -------
@@ -208,6 +213,9 @@ def export_to_cimxml(data,
         # the per-instance pipeline is pandas (groupby + engine contract)
         logger.debug("format=cimxml: polars input → pandas")
         data = data.to_pandas(use_pyarrow_extension_array=True)
+    if datatypes and engine == "auto":
+        logger.debug("cimxml engine set: python_lxml (datatypes=True not yet in cython engine)")
+        engine = "python_lxml"
     engine_name, engine_module = get_cimxml_engine(engine)
     generate = engine_module.generate_xml
 
@@ -221,13 +229,13 @@ def export_to_cimxml(data,
         with ProcessPoolExecutor(max_workers=max_workers) as executor:
             futures = [executor.submit(generate, instance, rdf_map, namespace_map,
                                        class_KEY=class_KEY, export_undefined=export_undefined,
-                                       comment=comment, debug=debug)
+                                       comment=comment, debug=debug, datatypes=datatypes)
                        for _, instance in instances]
             xml_documents = [future.result() for future in futures]
     else:
         xml_documents = [generate(instance, rdf_map, namespace_map,
                                   class_KEY=class_KEY, export_undefined=export_undefined,
-                                  comment=comment, debug=debug)
+                                  comment=comment, debug=debug, datatypes=datatypes)
                          for _, instance in instances]
 
     # generate returns None for instances skipped due to missing mapping

--- a/triplets/export/cimxml_pandas.py
+++ b/triplets/export/cimxml_pandas.py
@@ -15,6 +15,8 @@ from .cimxml_utils import load_rdf_map, resolve_instance_config
 
 logger = logging.getLogger(__name__)
 
+RDF_NS = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+
 
 def _print_duration(text, start_time):
     """Print duration between now and start time.
@@ -70,7 +72,8 @@ def generate_xml(instance_data,
                  class_KEY="Type",
                  export_undefined=True,
                  comment=None,
-                 debug=False):
+                 debug=False,
+                 datatypes=False):
     """
         Generate an RDF XML file from a triplet dataset instance.
 
@@ -96,6 +99,9 @@ def generate_xml(instance_data,
             If False, skip unmapped elements with a warning.
         comment : str, optional
             Optional comment to insert at the top of the XML output (as XML comment).
+        datatypes : bool, default False
+            If True, annotate literal elements with rdf:datatype from the schema's
+            xsd:type (like the N-Quads export); xsd:string stays unannotated.
         debug : bool, default False
             If True, log detailed timing and debug information during processing.
 
@@ -137,6 +143,12 @@ def generate_xml(instance_data,
 
     rdf_map = load_rdf_map(rdf_map)
     file_name, namespace_map, instance_rdf_map = resolve_instance_config(instance_data, rdf_map, namespace_map)
+
+    key_datatypes = {}
+    if datatypes:
+        # same KEY → xsd URI mapping the N-Quads export uses (string → None, anyURI excluded)
+        from .nquads_utils import build_key_metadata
+        _, _, key_datatypes = build_key_metadata(rdf_map)
 
     if instance_rdf_map is None:
         logger.warning("No rdf mapping available for {}".format(file_name))
@@ -236,6 +248,9 @@ def generate_xml(instance_data,
                     tag.attrib[_get_qname(attrib["attribute"])] = f"{value_prefix}{VALUE}"
                 else:
                     tag.text = f"{text_prefix}{VALUE}"
+                    datatype = key_datatypes.get(KEY)
+                    if datatype:
+                        tag.attrib[_get_qname(RDF_NS, "datatype")] = datatype
 
                 _object.append(tag)
 
@@ -245,6 +260,11 @@ def generate_xml(instance_data,
                 if export_undefined:
                     tag = E(KEY)
                     tag.text = str(VALUE)
+                    # key_datatypes spans all schema profiles, so annotation works
+                    # even when instance profile resolution fell through
+                    datatype = key_datatypes.get(KEY)
+                    if datatype:
+                        tag.attrib[_get_qname(RDF_NS, "datatype")] = datatype
 
                     _object.append(tag)
 

--- a/triplets/export/cimxml_pugixml.py
+++ b/triplets/export/cimxml_pugixml.py
@@ -40,7 +40,8 @@ def generate_xml(instance_data,
                  class_KEY="Type",
                  export_undefined=True,
                  comment=None,
-                 debug=False):
+                 debug=False,
+                 datatypes=False):
     """Generate an RDF XML file from a triplet dataset instance.
 
     Same parameters and return value as :func:`cimxml_pandas.generate_xml`;
@@ -51,6 +52,10 @@ def generate_xml(instance_data,
     dict
         {'filename': str, 'file': bytes (UTF-8 XML)}
     """
+    if datatypes:
+        raise NotImplementedError(
+            "rdf:datatype annotations are not implemented in the cython_pugixml engine yet — "
+            "use engine='python_lxml' (engine='auto' picks it automatically when datatypes=True)")
     rdf_map = load_rdf_map(rdf_map)
     file_name, namespace_map, instance_rdf_map = resolve_instance_config(instance_data, rdf_map, namespace_map)
 


### PR DESCRIPTION
export_to_cimxml(..., datatypes=True) annotates literal elements with
rdf:datatype from the schema's xsd:type, exactly like the N-Quads
export (shared nquads_utils.build_key_metadata: xsd:string stays plain,
xsd:anyURI excluded):

  <cim:Conductor.length rdf:datatype="http://www.w3.org/2001/XMLSchema#float">44.84</...>

- python_lxml engine only for now; engine="auto" steers to it when
  datatypes=True, explicit cython_pugixml + datatypes raises
  NotImplementedError with guidance
- annotation also applies on the export_undefined path — key_datatypes
  spans all schema profiles, so it works even when instance profile
  resolution falls through (the known CGMES 3.0 header gap)
- schema-optional: no xsd:type info in the schema → no annotations
- typed output reimports identically (parser ignores the attribute)
