### PR TITLE
feat: schema-driven profile resolution, export_undefined=False default

### DIFF
--- a/docs/migration_0.0_to_0.1.md
+++ b/docs/migration_0.0_to_0.1.md
@@ -133,6 +133,21 @@ If your code built triplet rows with numeric `VALUE`s by hand, the exports now
 tolerate them, but converting with `data["VALUE"].astype(str)` keeps your data
 within the contract.
 
+### `export_to_cimxml` exports schema-defined content only by default
+
+`export_undefined` now defaults to **False**: internal structures
+(`Distribution`, `NamespaceMap` and any class/attribute without a schema
+definition) are no longer written into CIM XML exports. Pass
+`export_undefined=True` to include them — they are emitted under the
+`http://triplets#` namespace (making the output valid, strict-parser-safe
+RDF/XML; previously they were non-namespaced elements).
+
+Profile resolution is schema-driven now: the schema's own `ProfileMetadata`
+(`keyword`, `versionIRI`, `conformsTo`) is matched against the instance
+header (`Model.messageType`, `keyword`, `Model.profile`, `conformsTo`), so
+CGMES 2.4.15, CGMES 3.0 and NetworkCode headers all resolve to the right
+profile section.
+
 ### DataFrame methods
 
 The old monkey-patched methods (`data.type_tableview(...)`) still work but the recommended

--- a/docs/source/guides/migration_0.0_to_0.1.md
+++ b/docs/source/guides/migration_0.0_to_0.1.md
@@ -133,6 +133,21 @@ If your code built triplet rows with numeric `VALUE`s by hand, the exports now
 tolerate them, but converting with `data["VALUE"].astype(str)` keeps your data
 within the contract.
 
+### `export_to_cimxml` exports schema-defined content only by default
+
+`export_undefined` now defaults to **False**: internal structures
+(`Distribution`, `NamespaceMap` and any class/attribute without a schema
+definition) are no longer written into CIM XML exports. Pass
+`export_undefined=True` to include them — they are emitted under the
+`http://triplets#` namespace (making the output valid, strict-parser-safe
+RDF/XML; previously they were non-namespaced elements).
+
+Profile resolution is schema-driven now: the schema's own `ProfileMetadata`
+(`keyword`, `versionIRI`, `conformsTo`) is matched against the instance
+header (`Model.messageType`, `keyword`, `Model.profile`, `conformsTo`), so
+CGMES 2.4.15, CGMES 3.0 and NetworkCode headers all resolve to the right
+profile section.
+
 ### DataFrame methods
 
 The old monkey-patched methods (`data.type_tableview(...)`) still work but the recommended

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -569,7 +569,7 @@ class TestExportToCimxml:
         """datatypes=True annotates literals with rdf:datatype like the nquads export."""
         from triplets.export_schema import schemas
         result = svedala_eq.export_to_cimxml(
-            rdf_map=schemas.ENTSOE_CGMES_2_4_15_552_ED1,
+            rdf_map=schemas.ENTSOE_CGMES_3_0_0_552_ED1,
             export_type="xml_per_instance",
             export_to_memory=True,
             datatypes=True,  # engine=auto must steer to python_lxml

--- a/triplets/export/__init__.py
+++ b/triplets/export/__init__.py
@@ -143,7 +143,7 @@ def export_to_cimxml(data,
                      rdf_map=None,
                      namespace_map=None,
                      class_KEY="Type",
-                     export_undefined=True,
+                     export_undefined=False,
                      export_type=ExportType.XML_PER_INSTANCE_ZIP_PER_XML,
                      global_zip_filename="Export.zip",
                      debug=False,
@@ -168,8 +168,11 @@ def export_to_cimxml(data,
         Namespace prefix-to-URI mapping (see :func:`generate_xml`).
     class_KEY : str, default "Type"
         Key identifying object types in triplet data.
-    export_undefined : bool, default True
-        Export unmapped classes/attributes with default RDF syntax.
+    export_undefined : bool, default False
+        If True, also export classes/attributes without a schema definition
+        (internal structures like Distribution/NamespaceMap) under the
+        http://triplets# namespace. Normal exports carry only schema-defined
+        content. (The cython engine emits undefined elements un-namespaced.)
     export_type : ExportType or str, default ExportType.XML_PER_INSTANCE_ZIP_PER_XML
         Export format:
         - ``XML_PER_INSTANCE``: One XML file per instance.

--- a/triplets/export/cimxml_pandas.py
+++ b/triplets/export/cimxml_pandas.py
@@ -11,7 +11,7 @@ from lxml import etree
 from lxml.builder import ElementMaker
 from lxml.etree import QName
 
-from .cimxml_utils import load_rdf_map, resolve_instance_config
+from .cimxml_utils import TRIPLETS_NS, load_rdf_map, resolve_instance_config
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ def generate_xml(instance_data,
                  rdf_map=None,
                  namespace_map=None,
                  class_KEY="Type",
-                 export_undefined=True,
+                 export_undefined=False,
                  comment=None,
                  debug=False,
                  datatypes=False):
@@ -94,9 +94,11 @@ def generate_xml(instance_data,
             Must include ``"rdf"`` namespace. If ``None``, inferred from ``rdf_map`` or instance.
         class_KEY : str, default "Type"
             Column key used to identify object class/type in the triplet data.
-        export_undefined : bool, default True
-            If True, export classes and attributes without explicit mapping using default RDF settings.
-            If False, skip unmapped elements with a warning.
+        export_undefined : bool, default False
+            If True, also export classes and attributes without a schema definition
+            (internal structures like Distribution/NamespaceMap) under the
+            http://triplets# namespace. Off by default — normal exports carry
+            only schema-defined content.
         comment : str, optional
             Optional comment to insert at the top of the XML output (as XML comment).
         datatypes : bool, default False
@@ -156,6 +158,9 @@ def generate_xml(instance_data,
             logger.warning("File not created for {}".format(file_name))
             return
 
+    if export_undefined:
+        namespace_map = {**namespace_map, "triplets": TRIPLETS_NS}
+
     # Create element builder
     E = ElementMaker(nsmap=namespace_map)
 
@@ -193,7 +198,7 @@ def generate_xml(instance_data,
             logger.debug("Definition missing for class: {} with {}: ".format(class_name, ID))
 
             if export_undefined:
-                class_namespace = None
+                class_namespace = TRIPLETS_NS
                 id_name = "{http://www.w3.org/1999/02/22-rdf-syntax-ns#}about"
                 id_value_prefix = "urn:uuid:"
             else:
@@ -258,7 +263,7 @@ def generate_xml(instance_data,
                 logger.debug("Definition missing for tag: " + KEY)
 
                 if export_undefined:
-                    tag = E(KEY)
+                    tag = E(_get_qname(TRIPLETS_NS, KEY))
                     tag.text = str(VALUE)
                     # key_datatypes spans all schema profiles, so annotation works
                     # even when instance profile resolution fell through

--- a/triplets/export/cimxml_pugixml.py
+++ b/triplets/export/cimxml_pugixml.py
@@ -38,7 +38,7 @@ def generate_xml(instance_data,
                  rdf_map=None,
                  namespace_map=None,
                  class_KEY="Type",
-                 export_undefined=True,
+                 export_undefined=False,
                  comment=None,
                  debug=False,
                  datatypes=False):

--- a/triplets/export/cimxml_utils.py
+++ b/triplets/export/cimxml_utils.py
@@ -10,9 +10,9 @@ from triplets.tools import get_namespace_map
 
 logger = logging.getLogger(__name__)
 
-# Maps a substring of the Model.profile URL to the export schema sub-key.
-# Used when the instance header has no Model.messageType (e.g. CGMES 3.0).
-# TODO - needs to be extended and made more intelligent, maybe scan profile?
+# Legacy fallback only: maps a substring of old-style (CGMES 2.4.15)
+# Model.profile URLs to the schema section. Modern schemas resolve via their
+# embedded ProfileMetadata (keyword / versionIRI / conformsTo) instead.
 PROFILE_URL_MAP = {
     "EquipmentCore": "EQ",
     "SteadyState": "SSH",
@@ -22,6 +22,9 @@ PROFILE_URL_MAP = {
     "TopologyBoundary": "TPBD",
 }
 
+# Namespace for internal/undefined structures when export_undefined=True
+TRIPLETS_NS = "http://triplets#"
+
 
 def load_rdf_map(rdf_map):
     """Return the export schema as a dict; load from JSON file path if needed."""
@@ -29,6 +32,38 @@ def load_rdf_map(rdf_map):
         return rdf_map
     with open(rdf_map, "r") as conf_file:
         return json.load(conf_file)
+
+
+def _profile_identity_index(rdf_map):
+    """Map every identifier a schema section declares to the section name.
+
+    Sections identify themselves via their key ("EQ") and the ProfileMetadata
+    entry: keyword ("EQ"), versionIRI (the profile URI, matches old-header
+    Model.profile), conformsTo. The schema defines what to match — no
+    hardcoded knowledge per CGMES generation.
+    """
+    index = {}
+    for section_name, section in rdf_map.items():
+        if not isinstance(section, dict):
+            continue
+        metadata = section.get("ProfileMetadata", {})
+        identifiers = [section_name, metadata.get("keyword"),
+                       metadata.get("versionIRI"), metadata.get("conformsTo")]
+        for identifier in identifiers:
+            if isinstance(identifier, str) and identifier:
+                index.setdefault(identifier, section_name)
+    return index
+
+
+def _instance_profile_hints(instance_data):
+    """Profile references the instance header may carry, in priority order:
+    old header messageType, new dcat:Dataset keyword, then the URI fields
+    (both can repeat — e.g. multiple Model.profile rows)."""
+    hints = []
+    for key in ("Model.messageType", "keyword", "Model.profile", "conformsTo"):
+        rows = instance_data[instance_data["KEY"] == key]
+        hints.extend(str(value) for value in rows["VALUE"] if value is not None)
+    return hints
 
 
 def _first_value(instance_data, key):
@@ -47,8 +82,11 @@ def resolve_instance_config(instance_data, rdf_map, namespace_map=None):
     tuple (file_name, namespace_map, instance_rdf_map)
         file_name : from the instance 'label' (source filename) or a new UUID
         namespace_map : given > instance NamespaceMap > schema ProfileNamespaceMap
-        instance_rdf_map : profile sub-schema (via Model.messageType or
-            Model.profile URL) or the schema root when no profile matches
+        instance_rdf_map : profile section matched by the schema's own identity
+            metadata (section key / keyword / versionIRI / conformsTo) against
+            the instance header (Model.messageType, keyword, Model.profile,
+            conformsTo); legacy URL-substring fallback for 2.4.15-era URLs;
+            schema root when nothing matches
     """
     if not namespace_map:
         namespace_map, xml_base = get_namespace_map(instance_data)
@@ -56,22 +94,26 @@ def resolve_instance_config(instance_data, rdf_map, namespace_map=None):
     # Filename is kept under label
     file_name = _first_value(instance_data, "label") or f"{uuid.uuid4()}.xml"
 
-    # Find schema reference to be used for export
-    # TODO remove dependency on this header field, which might not be present
-    # TODO: Refactor this, if schema is provided, the information how to pick it up should be in the schema
-    instance_type = _first_value(instance_data, "Model.messageType")
-
-    if not instance_type:
-        profile_url = _first_value(instance_data, "Model.profile")
-        if profile_url:
-            for url_part, profile in PROFILE_URL_MAP.items():
-                if url_part in profile_url:
-                    instance_type = profile
+    identity_index = _profile_identity_index(rdf_map)
+    instance_section = None
+    hints = _instance_profile_hints(instance_data)
+    for hint in hints:
+        if hint in identity_index:
+            instance_section = identity_index[hint]
+            break
+    if instance_section is None:
+        # legacy 2.4.15 profile URLs carry no exact schema identity — substring map
+        for hint in hints:
+            for url_part, section in PROFILE_URL_MAP.items():
+                if url_part in hint:
+                    instance_section = section
                     break
+            if instance_section:
+                break
+    if instance_section is None and hints:
+        logger.warning("No schema profile matched instance header hints %s — using schema root", hints[:4])
 
-    # If there is sub structure available in schema get it, otherwise use root definitions
-    # TODO - needs revision, add support both for md:FullModel, dcat:DataSet and without profile definiton
-    instance_rdf_map = rdf_map.get(instance_type, rdf_map)
+    instance_rdf_map = rdf_map.get(instance_section, rdf_map)
 
     # No map in function call, nor in instance data, use profile map
     if not namespace_map and instance_rdf_map:


### PR DESCRIPTION
Profile resolution now matches the schema's own identity metadata
(ProfileMetadata: keyword / versionIRI / conformsTo + the section key)
against whatever the instance header offers (Model.messageType, dcat
keyword, Model.profile, conformsTo) — the schema defines what to match.
Verified: CGMES 2.4.15 (messageType + legacy URL fallback), CGMES 3.0
(Model.profile == versionIRI), NetworkCode dcat headers (keyword). All
keep 100% of schema-defined objects. Legacy URL-substring map remains
as fallback for 2.4.15-era profile URLs only.

export_undefined now defaults to False: internal structures
(Distribution, NamespaceMap, anything schema-undefined) stay out of
normal exports. With export_undefined=True they are emitted under the
http://triplets# namespace — valid, strict-parser-safe RDF/XML instead
of the previous non-namespaced elements (which pyoxigraph rejected).

test_datatypes_flag schema pairing corrected (3.0 data with 3.0
schema — it previously passed only through the undefined branch).
Migration guide updated.
