### PR TITLE
refactor: drop aniso8601 — pandas.Timestamp parses CGMES timestamps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     # "'Series' object has no attribute '_pa_array'" (fixed upstream in 2.3)
     "pandas>=2.0,!=2.2.*",
     "lxml>=4.9",
-    "aniso8601",
 ]
 
 [project.scripts]

--- a/triplets/cgmes_tools/pandas_engine.py
+++ b/triplets/cgmes_tools/pandas_engine.py
@@ -15,7 +15,6 @@ import os
 import webbrowser
 import pandas
 import math
-import aniso8601
 
 from uuid import uuid4
 from lxml import etree
@@ -186,7 +185,7 @@ def get_filename_from_metadata(meta_data, file_type="xml", filename_mask=default
     # DateTime fields from text to DateTime
     DateTime_fields = ["scenarioTime"]#, 'created']
     for field in DateTime_fields:
-        meta_data[field] = aniso8601.parse_datetime(meta_data[field])
+        meta_data[field] = pandas.Timestamp(meta_data[field])  # lenient ISO parsing, pandas is a core dep
 
     # Integers to integers
     meta_data["version"] = int(meta_data["version"])


### PR DESCRIPTION
Closes #30

Single call site (get_filename_from_metadata scenarioTime). pandas is a
core dependency and its ISO parser is lenient; one fewer core dep.
