### PR TITLE
ci: bump artifact actions to Node 24 majors; cgmes prints to logger

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -31,7 +31,7 @@ jobs:
       - run: pip install build
       - run: python -m build --sdist
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -102,7 +102,7 @@ jobs:
           CIBW_TEST_REQUIRES: "pytest pyarrow>=14.0"
           CIBW_TEST_COMMAND: "pytest {project}/tests/test_parser.py -q --tb=short -k \"not realgrid\""
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.os }}-${{ matrix.arch }}
           path: dist/*.whl
@@ -119,7 +119,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true

--- a/triplets/cgmes_tools/pandas_engine.py
+++ b/triplets/cgmes_tools/pandas_engine.py
@@ -105,7 +105,7 @@ def get_metadata_from_filename(file_name):
         file_metadata["Model.version"] = file_meta_list
         file_metadata["Model.processType"] = ""
 
-        print("Warning - only 4 meta elements found, expecting 5, setting Model.processType to empty string")
+        logger.warning("Only 4 meta elements found, expecting 5, setting Model.processType to empty string")
 
     # Naming after QoDC 2.1, always 5 positions
     elif len(file_meta_list) == 5:
@@ -117,7 +117,7 @@ def get_metadata_from_filename(file_name):
         file_metadata["Model.version"] = file_meta_list
 
     else:
-        print("Non CGMES file {}".format(file_name))
+        logger.warning("Non CGMES file {}".format(file_name))
 
     if file_metadata.get("Model.modelingEntity", False):
 


### PR DESCRIPTION
Closes #40

- actions/upload-artifact v5 → v7, download-artifact v5 → v8 (Node.js 20
  actions forced to Node 24 on June 16, 2026)
- last two print() warnings in cgmes_tools converted to logger.warning
