### PR TITLE
perf: N-Quads polars writes via Rust write_csv — 2.3x

### DIFF
--- a/triplets/export/nquads_polars.py
+++ b/triplets/export/nquads_polars.py
@@ -70,12 +70,19 @@ def export_to_nquads(data, path, rdf_map=None):
                .otherwise(plain_literal))
 
     # one lazy plan: stringify (KEY/INSTANCE_ID may be Categorical), filter
-    # null VALUE rows, build the quad lines, collect once
+    # null VALUE rows, build the four quad terms + the "." terminator as
+    # separate columns, collect once. The aliases are required (not cosmetic):
+    # several terms auto-name to "literal" and collide in select otherwise.
     quads = (data.lazy()
              .with_columns(pl.col("ID", "KEY", "VALUE", "INSTANCE_ID").cast(pl.Utf8))
              .filter(pl.col("VALUE").is_not_null())
-             .select(pl.format("{} {} {} {} .", subject, predicate, objects, graph).alias("quad"))
-             .collect()["quad"])
+             .select(subject.alias("s"), predicate.alias("p"), objects.alias("o"),
+                     graph.alias("g"), pl.lit(".").alias("end"))
+             .collect())
 
-    with open(path, "w") as f:
-        f.write("\n".join(quads.to_list()) + "\n")
+    # write straight from Rust with a space separator — the CSV writer joins
+    # the columns into "<s> <p> <o> <g> ." per row. No Python string
+    # materialization, no outer pl.format (~2.3x faster than collect → to_list
+    # → "\n".join). quote_style="never" keeps each term verbatim (literals
+    # carry their own quotes / internal spaces, no CSV escaping wanted).
+    quads.write_csv(path, include_header=False, quote_style="never", separator=" ")


### PR DESCRIPTION
The lazy plan built the quad lines, then collect → to_list → "\n".join
materialized 1.14M Python strings (about half the runtime). Instead,
select the four terms + "." as separate columns and write straight from
Rust with write_csv(separator=" ", quote_style="never") — the writer
joins them into "<s> <p> <o> <g> ." per row, no Python string churn and
no outer pl.format pass.

RealGrid 1.14M rows: 0.86s → 0.37s, byte-identical output. quote_style
"never" keeps literals verbatim (they carry their own quotes / internal
spaces); a space separator is the N-Quads term delimiter. Column aliases
are load-bearing — several terms auto-name to "literal" and collide.
